### PR TITLE
Dashboard UI overhaul: sidebar nav, visual upgrades, data fixes

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -1,9 +1,14 @@
-name: Daily Update
+name: Hourly Update
 
 on:
   schedule:
-    - cron: '0 8 * * *'  # Daily 8am UTC
-  workflow_dispatch:       # Manual trigger
+    - cron: '45 * * * *'  # Every hour at :45 (after queue monitor at :15)
+  workflow_dispatch:
+    inputs:
+      force_full:
+        description: 'Force full data collection (skip freshness check)'
+        required: false
+        default: 'false'
 
 permissions:
   contents: write
@@ -21,46 +26,97 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml requests
 
+      # Min-frequency logic: only run heavy GitHub API collection if data
+      # is older than 1 hour, or if force_full is set. Queue and CI data
+      # have their own dedicated workflows, so we always deploy but only
+      # re-collect GitHub data when stale.
+      - name: Check data freshness
+        id: freshness
+        run: |
+          FORCE="${{ github.event.inputs.force_full || 'false' }}"
+          if [ "$FORCE" = "true" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "Data collection forced by manual trigger"
+            exit 0
+          fi
+          # Check age of the main data file
+          if [ -f data/vllm/prs.json ]; then
+            FILE_TS=$(python3 -c "
+          import json, datetime
+          try:
+              d = json.load(open('data/vllm/prs.json'))
+              ts = d.get('collected_at', '')
+              if ts:
+                  dt = datetime.datetime.fromisoformat(ts.replace('Z', '+00:00'))
+                  age = (datetime.datetime.now(datetime.timezone.utc) - dt).total_seconds()
+                  print(int(age))
+              else:
+                  print(999999)
+          except:
+              print(999999)
+          ")
+            echo "Data age: ${FILE_TS}s"
+            # Stale if older than 3600s (1 hour)
+            if [ "$FILE_TS" -gt 3600 ]; then
+              echo "stale=true" >> "$GITHUB_OUTPUT"
+              echo "Data is stale, will collect"
+            else
+              echo "stale=false" >> "$GITHUB_OUTPUT"
+              echo "Data is fresh, skipping collection"
+            fi
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "No data file found, will collect"
+          fi
+
       - name: Collect data
+        if: steps.freshness.outputs.stale == 'true'
         run: python scripts/collect.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Collect test results
+        if: steps.freshness.outputs.stale == 'true'
         run: python scripts/collect_tests.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Collect activity metrics
+        if: steps.freshness.outputs.stale == 'true'
         run: python scripts/collect_activity.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Collect build times
+        if: steps.freshness.outputs.stale == 'true'
         run: python scripts/collect_build_times.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Collect vLLM CI data from Buildkite
-        if: env.BUILDKITE_TOKEN != ''
+        if: steps.freshness.outputs.stale == 'true' && env.BUILDKITE_TOKEN != ''
         run: python scripts/collect_ci.py --days 7 --output data/vllm/ci/
         env:
           BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
       - name: Take weekly snapshot
+        if: steps.freshness.outputs.stale == 'true'
         run: python scripts/snapshot.py
 
       - name: Render dashboards
+        if: steps.freshness.outputs.stale == 'true'
         run: python scripts/render.py
 
       - name: Commit and push
+        if: steps.freshness.outputs.stale == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/ dashboards/ docs/_data/ README.md
-          git diff --staged --quiet || git commit -m "daily update $(date -u +%Y-%m-%d)"
+          git diff --staged --quiet || git commit -m "update $(date -u +%Y-%m-%dT%H:%M)"
           git push
 
+      # Always deploy — picks up queue snapshots and CI data from other workflows
       - name: Assemble site
         run: |
           mkdir -p _site

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           script: |
             const prNum = context.payload.pull_request.number;
-            const url = `https://sunway513.github.io/project-dashboard/pr-preview/pr-${prNum}/`;
+            const url = `https://${context.repo.owner}.github.io/${context.repo.repo}/pr-preview/pr-${prNum}/`;
             const body = `📋 **Preview deployed**: ${url}`;
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: prNum

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Project Dashboard
 
-Auto-updated tracking of AMD GPU ecosystem projects. Last updated: **2026-03-23 08:23 UTC**
+Auto-updated tracking of AMD GPU ecosystem projects.
+
+**Live Dashboard:** [andreaskaratzas.github.io/vllm-internal-project-dashboard](https://andreaskaratzas.github.io/vllm-internal-project-dashboard/)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -21,40 +21,75 @@ Auto-updated tracking of AMD GPU ecosystem projects. Last updated: **2026-03-23 
 
 ## Live Dashboard
 
-Interactive dashboard with 4 views: **Projects**, **Test Parity**, **Activity**, and **Trends**.
+Interactive dashboard with sidebar navigation and multiple views.
 
-Hosted on GitHub Pages — deployed automatically on every push to main.
+**Hosted on GitHub Pages** — deployed automatically every hour.
 
-## Views
+### Views
 
 | View | Description |
 |------|-------------|
 | **Projects** | Per-project cards with PRs, issues, releases, and weekly activity |
-| **Test Parity** | ROCm vs CUDA test pass rates with CUDA parity ratio |
+| **Test Parity** | ROCm vs CUDA/Upstream test pass rates with parity analysis |
 | **Activity** | PR velocity, CI health, CI signal time, contributor stats, issue health, release cadence |
 | **Trends** | Weekly trend charts (PRs merged, open issues, contributors, TTM, CI signal, test pass rate) |
+| **Builds** | Dependency graph, build times, and target tracking |
 
-## Markdown Dashboards
+### vLLM CI Views
 
-- [PR Tracker](dashboards/pr-tracker.md) — all tracked PRs across projects
-- [Weekly Digest](dashboards/weekly-digest.md) — weekly summary of releases, PRs, and issues
+| View | Description |
+|------|-------------|
+| **CI Health** | AMD pass rate, hardware breakdown (MI250/MI325/MI355), test area heatmap, grouped parity analysis, flaky tests, top offenders, config parity, engineer activity |
+| **CI Analytics** | Side-by-side pipeline comparison (AMD CI vs Upstream CI), failure rankings, duration rankings, queue wait time comparison (AMD queues vs Other agents) |
+| **Queue Monitor** | Real-time queue time-series chart with per-queue toggles, interval selector, waiting/running metrics |
+
+### Tools
+
+| View | Description |
+|------|-------------|
+| **AI Op Coverage** | Operator coverage matrix across AMD and NVIDIA backends |
 
 ## Data Collection
 
-Data is collected daily at 8am UTC via GitHub Actions (`daily-update.yml`).
+Data is collected and deployed via GitHub Actions workflows:
+
+| Workflow | Schedule | Purpose |
+|----------|----------|---------|
+| `daily-update.yml` | Hourly (:45) | Collects GitHub data with min-frequency guard, always deploys site |
+| `ci-collect.yml` | Daily (1 PM UTC) + webhook | Collects vLLM CI nightly build data from Buildkite |
+| `queue-monitor.yml` | Hourly (:15) | Collects Buildkite queue snapshots for time-series charts |
+
+### Min-frequency logic
+
+The hourly update workflow checks data freshness before running expensive GitHub API calls. If data was collected less than 1 hour ago, it skips collection but still deploys the site (picking up queue snapshots and CI data committed by other workflows). This ensures the live site is always current without wasting API quota.
+
+### Scripts
 
 | Script | Purpose |
 |--------|---------|
 | `scripts/collect.py` | PRs, issues, releases from GitHub API |
-| `scripts/collect_tests.py` | ROCm/CUDA test results from CI artifacts (JUnit XML + job-level) |
-| `scripts/collect_activity.py` | PR velocity, CI health, contributor stats, issue health |
+| `scripts/collect_tests.py` | ROCm/CUDA test results from CI artifacts |
+| `scripts/collect_activity.py` | PR velocity, CI health, contributor stats |
+| `scripts/collect_build_times.py` | Build time tracking and targets |
+| `scripts/collect_ci.py` | vLLM Buildkite CI data (nightly builds, test results, parity) |
+| `scripts/vllm/collect_queue_snapshot.py` | Buildkite queue snapshot for time-series |
+| `scripts/vllm/collect_analytics.py` | CI analytics (failure/duration rankings, queue stats) |
+| `scripts/vllm/collect_activity.py` | Engineer activity profiles and PR scoring |
+| `scripts/vllm/config_parity.py` | AMD vs NVIDIA config comparison |
 | `scripts/snapshot.py` | Weekly trend snapshots for historical charts |
 | `scripts/render.py` | Generate markdown dashboards and site data |
 
-To run manually:
+### Secrets
+
+| Secret | Required by | Purpose |
+|--------|-------------|---------|
+| `GITHUB_TOKEN` | All workflows | GitHub API access (auto-provided) |
+| `BUILDKITE_TOKEN` | `ci-collect.yml`, `queue-monitor.yml`, `daily-update.yml` | Buildkite API access for CI data |
+
+### Manual run
 
 ```bash
-pip install pyyaml
+pip install pyyaml requests
 python scripts/collect.py
 python scripts/collect_tests.py
 python scripts/collect_activity.py
@@ -63,3 +98,8 @@ python scripts/render.py
 ```
 
 Configure tracked projects in [`config/projects.yaml`](config/projects.yaml).
+
+## Markdown Dashboards
+
+- [PR Tracker](dashboards/pr-tracker.md) — all tracked PRs across projects
+- [Weekly Digest](dashboards/weekly-digest.md) — weekly summary of releases, PRs, and issues

--- a/docs/assets/css/dashboard.css
+++ b/docs/assets/css/dashboard.css
@@ -162,8 +162,17 @@ a:hover {
 #main-content {
   margin-left: var(--sidebar-width);
   flex: 1;
-  padding: 24px 32px;
+  padding: 28px 36px;
   min-height: 100vh;
+  font-size: 15px;
+}
+
+#main-content h2 {
+  font-size: 22px;
+}
+
+#main-content h3 {
+  font-size: 17px;
 }
 
 /* ═══════════════════════════════════════════════════════════
@@ -238,6 +247,18 @@ a:hover {
   padding: 16px 20px;
   overflow-y: auto;
   flex: 1;
+}
+
+.overlay-body table {
+  font-size: 14px;
+}
+
+.overlay-row-missing {
+  opacity: 0.6;
+}
+
+.overlay-row-missing td:first-child {
+  font-style: italic;
 }
 
 /* Tab panels with fade animation */
@@ -648,10 +669,10 @@ footer {
 }
 
 .pass-rate-label {
-  width: 120px;
+  width: 160px;
   font-weight: 600;
   flex-shrink: 0;
-  font-size: 12px;
+  font-size: 13px;
 }
 
 .pass-rate-bar-bg {

--- a/docs/assets/css/dashboard.css
+++ b/docs/assets/css/dashboard.css
@@ -15,6 +15,8 @@
   --accent-purple: #8957e5;
   --accent-blue: #1f6feb;
   --accent-orange: #d29922;
+  --sidebar-width: 220px;
+  --transition-speed: 0.25s;
 }
 
 * {
@@ -28,9 +30,8 @@ body {
   color: var(--text);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   line-height: 1.5;
-  padding: 24px;
-  max-width: 1200px;
-  margin: 0 auto;
+  display: flex;
+  min-height: 100vh;
 }
 
 a {
@@ -42,63 +43,159 @@ a:hover {
   text-decoration: underline;
 }
 
-/* Header */
-header {
-  margin-bottom: 24px;
-  padding-bottom: 16px;
+/* ═══════════════════════════════════════════════════════════
+   SIDEBAR
+   ═══════════════════════════════════════════════════════════ */
+
+#sidebar {
+  width: var(--sidebar-width);
+  min-height: 100vh;
+  background: var(--card-bg);
+  border-right: 1px solid var(--border);
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  transition: transform var(--transition-speed) ease;
+}
+
+.sidebar-header {
+  padding: 20px 16px 12px;
   border-bottom: 1px solid var(--border);
 }
 
-header h1 {
-  font-size: 24px;
-  font-weight: 600;
+.sidebar-header h1 {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.2px;
 }
 
 #last-updated {
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: 11px;
   margin-top: 4px;
 }
 
-/* Tab Navigation */
-#tab-bar {
+#sidebar-nav {
+  padding: 8px 8px 16px;
   display: flex;
-  gap: 4px;
-  margin-bottom: 24px;
-  border-bottom: 1px solid var(--border);
+  flex-direction: column;
+  gap: 2px;
 }
 
-.tab-btn {
+.nav-section-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-muted);
+  padding: 16px 10px 4px;
+  opacity: 0.7;
+}
+
+.nav-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
   background: none;
   border: none;
-  border-bottom: 2px solid transparent;
+  border-radius: 6px;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
-  padding: 8px 16px;
+  padding: 8px 10px;
   cursor: pointer;
   font-family: inherit;
-  transition: color 0.15s, border-color 0.15s;
+  text-align: left;
+  transition: all var(--transition-speed) ease;
+  position: relative;
+  overflow: hidden;
 }
 
-.tab-btn:hover {
+.nav-btn::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--accent-blue);
+  border-radius: 0 3px 3px 0;
+  transform: scaleY(0);
+  transition: transform var(--transition-speed) ease;
+}
+
+.nav-btn:hover {
   color: var(--text);
+  background: var(--hover);
 }
 
-.tab-btn.active {
+.nav-btn.active {
   color: var(--text);
-  border-bottom-color: var(--link);
+  background: rgba(31, 111, 235, 0.1);
+  font-weight: 600;
 }
 
+.nav-btn.active::before {
+  transform: scaleY(1);
+}
+
+.nav-btn svg {
+  flex-shrink: 0;
+  opacity: 0.6;
+  transition: opacity var(--transition-speed) ease;
+}
+
+.nav-btn.active svg,
+.nav-btn:hover svg {
+  opacity: 1;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   MAIN CONTENT
+   ═══════════════════════════════════════════════════════════ */
+
+#main-content {
+  margin-left: var(--sidebar-width);
+  flex: 1;
+  padding: 24px 32px;
+  max-width: 1200px;
+  min-height: 100vh;
+}
+
+/* Tab panels with fade animation */
 .tab-panel {
   display: none;
+  animation: fadeIn 0.3s ease-out;
 }
 
 .tab-panel.active {
   display: block;
 }
 
-/* Parity View */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes scaleIn {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+/* ═══════════════════════════════════════════════════════════
+   PARITY VIEW
+   ═══════════════════════════════════════════════════════════ */
+
 #parity-view h2 {
   font-size: 16px;
   font-weight: 600;
@@ -117,6 +214,7 @@ header h1 {
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 16px;
+  animation: slideUp 0.4s ease-out;
 }
 
 .parity-card-header {
@@ -189,6 +287,12 @@ header h1 {
   border-radius: 8px;
   padding: 12px 16px;
   text-align: center;
+  transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+}
+
+.weekly-box:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
 }
 
 .weekly-box-opened {
@@ -260,7 +364,21 @@ header h1 {
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 16px;
+  transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+  animation: slideUp 0.4s ease-out both;
 }
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+}
+
+.card:nth-child(1) { animation-delay: 0.05s; }
+.card:nth-child(2) { animation-delay: 0.1s; }
+.card:nth-child(3) { animation-delay: 0.15s; }
+.card:nth-child(4) { animation-delay: 0.2s; }
+.card:nth-child(5) { animation-delay: 0.25s; }
+.card:nth-child(6) { animation-delay: 0.3s; }
 
 .card-header {
   display: flex;
@@ -326,16 +444,19 @@ header h1 {
   font-weight: 500;
   color: var(--text-muted);
   list-style: none;
+  transition: color 0.15s;
 }
 
 .week-activity summary::before {
   content: "\25B6 ";
   font-size: 10px;
   margin-right: 6px;
+  transition: transform 0.2s ease;
+  display: inline-block;
 }
 
 .week-activity[open] summary::before {
-  content: "\25BC ";
+  transform: rotate(90deg);
 }
 
 .week-activity summary:hover {
@@ -364,6 +485,7 @@ header h1 {
   font-weight: 500;
   color: var(--text-muted);
   list-style: none;
+  transition: color 0.15s;
 }
 
 .card details summary::before,
@@ -371,11 +493,13 @@ header h1 {
   content: "\25B6 ";
   font-size: 10px;
   margin-right: 6px;
+  transition: transform 0.2s ease;
+  display: inline-block;
 }
 
 .card details[open] summary::before,
 .parity-card details[open] summary::before {
-  content: "\25BC ";
+  transform: rotate(90deg);
 }
 
 .card details summary:hover,
@@ -428,12 +552,17 @@ header h1 {
 
 /* Footer */
 footer {
-  margin-top: 32px;
-  padding-top: 16px;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: var(--sidebar-width);
+  padding: 12px 16px;
   border-top: 1px solid var(--border);
   text-align: center;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: 11px;
+  background: var(--card-bg);
+  z-index: 100;
 }
 
 /* Test Results: Pass Rate Bars */
@@ -446,9 +575,10 @@ footer {
 }
 
 .pass-rate-label {
-  width: 48px;
+  width: 120px;
   font-weight: 600;
   flex-shrink: 0;
+  font-size: 12px;
 }
 
 .pass-rate-bar-bg {
@@ -463,7 +593,7 @@ footer {
 .pass-rate-bar-fill {
   height: 100%;
   border-radius: 4px;
-  transition: width 0.3s ease;
+  transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .pass-rate-pct {
@@ -542,7 +672,7 @@ footer {
 }
 
 /* ---------------------------------------------------------------------------
-   Activity View (Tab 3)
+   Activity View
    --------------------------------------------------------------------------- */
 
 #activity-view h2 {
@@ -569,6 +699,12 @@ footer {
   border-radius: 8px;
   padding: 12px 16px;
   text-align: center;
+  transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+}
+
+.activity-box:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
 }
 
 .activity-box-opened { border-top-color: var(--accent-green); }
@@ -601,6 +737,7 @@ footer {
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 16px;
+  animation: slideUp 0.3s ease-out both;
 }
 
 .activity-section h3 {
@@ -749,7 +886,7 @@ footer {
 }
 
 /* ---------------------------------------------------------------------------
-   Trends View (Tab 4)
+   Trends View
    --------------------------------------------------------------------------- */
 
 #trends-view h2 {
@@ -780,6 +917,11 @@ footer {
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 16px;
+  transition: transform var(--transition-speed) ease;
+}
+
+.trend-card:hover {
+  transform: translateY(-1px);
 }
 
 .trend-card h4 {
@@ -835,7 +977,7 @@ footer {
 .parity-meta { font-size: 12px; color: var(--text-muted); margin-top: 8px; }
 
 /* ---------------------------------------------------------------------------
-   Builds View (Tab 5)
+   Builds View
    --------------------------------------------------------------------------- */
 
 #builds-view h2 {
@@ -1025,8 +1167,6 @@ footer {
   border-radius: 3px;
 }
 
-/* (dep-arrows removed — edges now rendered by dagre SVG) */
-
 @media (max-width: 768px) {
   .build-summary-boxes {
     flex-wrap: wrap;
@@ -1049,7 +1189,7 @@ footer {
 }
 
 /* ---------------------------------------------------------------------------
-   Op Coverage View (Tab 5)
+   Op Coverage View
    --------------------------------------------------------------------------- */
 
 #op-coverage-view h2 {
@@ -1111,13 +1251,14 @@ footer {
   display: flex;
   align-items: center;
   gap: 12px;
+  transition: background var(--transition-speed) ease;
 }
 
 .oc-category summary::before {
   content: "\25B6";
   font-size: 10px;
   flex-shrink: 0;
-  transition: transform 0.15s;
+  transition: transform 0.2s ease;
 }
 
 .oc-category[open] summary::before {
@@ -1290,4 +1431,25 @@ a.oc-be-link .oc-be:hover { filter: brightness(1.3); }
   color: var(--text-muted);
   margin-top: 16px;
   text-align: right;
+}
+
+/* ---------------------------------------------------------------------------
+   Responsive: collapse sidebar on mobile
+   --------------------------------------------------------------------------- */
+
+@media (max-width: 900px) {
+  #sidebar {
+    transform: translateX(-100%);
+    width: 240px;
+  }
+  #sidebar.open {
+    transform: translateX(0);
+  }
+  #main-content {
+    margin-left: 0;
+    padding: 16px;
+  }
+  footer {
+    display: none;
+  }
 }

--- a/docs/assets/css/dashboard.css
+++ b/docs/assets/css/dashboard.css
@@ -163,8 +163,81 @@ a:hover {
   margin-left: var(--sidebar-width);
   flex: 1;
   padding: 24px 32px;
-  max-width: 1200px;
   min-height: 100vh;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   OVERLAY / MODAL
+   ═══════════════════════════════════════════════════════════ */
+
+.overlay-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fadeIn 0.2s ease-out;
+  backdrop-filter: blur(4px);
+}
+
+.overlay-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  width: 90%;
+  max-width: 800px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  animation: scaleIn 0.2s ease-out;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+.overlay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.overlay-header h3 {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.overlay-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 24px;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  transition: all 0.15s;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.overlay-close:hover {
+  background: var(--hover);
+  color: var(--text);
+}
+
+.overlay-body {
+  padding: 16px 20px;
+  overflow-y: auto;
+  flex: 1;
 }
 
 /* Tab panels with fade animation */

--- a/docs/assets/js/ci-analytics.js
+++ b/docs/assets/js/ci-analytics.js
@@ -1,7 +1,7 @@
 /**
- * CI Analytics — Rich interactive views: Builds, Jobs, Queue
- * Inspired by professional CI dashboards with pipeline selectors,
- * stacked bar charts, failure rankings, and queue analysis.
+ * CI Analytics — Streamlined comparison-first view.
+ * Side-by-side is the default and only pipeline view.
+ * Queue comparison: AMD queues vs Other agents (NVIDIA on top).
  */
 (function() {
   const C = {g:'#238636',y:'#d29922',o:'#db6d28',r:'#da3633',b:'#1f6feb',m:'#8b949e',t:'#e6edf3',bg:'#161b22',bg2:'#0d1117',bd:'#30363d',sf:'#a371f7'};
@@ -27,11 +27,11 @@
 
   function stateDot(state, size='10px') {
     const colors = {passed:C.g,failed:C.r,soft_fail:C.sf,canceled:C.m,running:C.b,scheduled:C.y,timed_out:C.o};
-    return h('span',{style:{display:'inline-block',width:size,height:size,borderRadius:'50%',background:colors[state]||C.m}});
+    return h('span',{style:{display:'inline-block',width:size,height:size,borderRadius:'50%',background:colors[state]||C.m,transition:'transform 0.2s'}});
   }
 
   function metricCard(label, value, sub, color) {
-    return h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'16px 20px',borderTop:`3px solid ${color||C.b}`}},[
+    return h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'16px 20px',borderTop:`3px solid ${color||C.b}`,transition:'transform 0.2s, box-shadow 0.2s'}},[
       h('div',{text:label,style:{fontSize:'11px',color:C.m,textTransform:'uppercase',letterSpacing:'.5px',marginBottom:'4px'}}),
       h('div',{html:String(value),style:{fontSize:'28px',fontWeight:'800',color:color||C.t,lineHeight:'1.1'}}),
       sub?h('div',{html:sub,style:{fontSize:'12px',color:C.m,marginTop:'4px'}}):null,
@@ -42,7 +42,7 @@
     const pct = max>0 ? Math.round(value/max*100) : 0;
     return h('div',{style:{display:'inline-flex',alignItems:'center',gap:'6px'}},[
       h('div',{style:{width:w,height:'8px',background:C.bd,borderRadius:'4px',overflow:'hidden'}},[
-        h('div',{style:{width:pct+'%',height:'100%',background:color,borderRadius:'4px',transition:'width .3s'}}),
+        h('div',{style:{width:pct+'%',height:'100%',background:color,borderRadius:'4px',transition:'width .6s cubic-bezier(0.4,0,0.2,1)'}}),
       ]),
       h('span',{text:pct+'%',style:{fontSize:'12px',color,fontWeight:'600',minWidth:'36px'}}),
     ]);
@@ -51,268 +51,215 @@
   const thS = a => ({textAlign:a||'left',padding:'8px 12px',borderBottom:`2px solid ${C.bd}`,color:C.m,fontSize:'10px',textTransform:'uppercase',fontWeight:'600',whiteSpace:'nowrap'});
   const tdS = a => ({textAlign:a||'left',padding:'6px 12px',borderBottom:`1px solid ${C.bd}`,color:C.t,fontSize:'13px'});
 
-  // ═══════════ BUILDS VIEW ═══════════
+  // ═══════════ COMPARISON VIEW (default) ═══════════
 
-  function renderBuildsView(box, data, pipeline) {
-    const d = data[pipeline]; if (!d) return;
-    const s = d.summary;
+  function renderComparisonView(box, data, pipelines) {
+    // Summary metrics across both pipelines
+    const summaryRow = h('div',{style:{display:'grid',gridTemplateColumns:'repeat(4,1fr)',gap:'12px',marginBottom:'20px'}});
 
-    // Metrics row — nightly-specific stats
-    const row = h('div',{style:{display:'grid',gridTemplateColumns:'repeat(4,1fr)',gap:'12px',marginBottom:'20px'}});
-    row.append(metricCard('Nightly Builds', s.total_builds, `Last ${d.days} days`, C.b));
-    row.append(metricCard('Jobs with Failures', s.jobs_with_failures, `of ${s.total_jobs_tracked} tracked`, s.jobs_with_failures>0?C.r:C.g));
-
-    // Find slowest and most failing job
-    const topDur = d.duration_ranking?.[0];
-    const topFail = d.failure_ranking?.[0];
-    row.append(metricCard('Slowest Job (p50)', topDur ? fmtDur(topDur.median_dur) : '—', topDur?.name?.slice(0,30)||'', C.o));
-    row.append(metricCard('Most Failures', topFail ? `${topFail.fail_rate}%` : '0%', topFail?.name?.slice(0,30)||'', C.r));
-    box.append(row);
-
-    // Stacked bar chart: pass/fail per day
-    if (d.daily_stats?.length > 1) {
-      const section = h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'20px',marginBottom:'20px'}});
-      section.append(h('h3',{text:`Build Pass/Fail — ${d.daily_stats[0]?.date} — ${d.daily_stats[d.daily_stats.length-1]?.date}`,style:{marginBottom:'12px',fontSize:'14px'}}));
-      const canvas = h('canvas',{style:{maxHeight:'220px'}});
-      section.append(canvas);
-      box.append(section);
-
-      new Chart(canvas, {
-        type: 'bar',
-        data: {
-          labels: d.daily_stats.map(x => x.date.slice(5)),
-          datasets: [
-            {label:'passed',data:d.daily_stats.map(x=>x.passed),backgroundColor:C.g,borderRadius:2},
-            {label:'failed',data:d.daily_stats.map(x=>x.failed),backgroundColor:C.r,borderRadius:2},
-          ]
-        },
-        options: {
-          responsive:true, plugins:{legend:{labels:{color:C.t}}},
-          scales:{
-            x:{stacked:true,ticks:{color:C.m},grid:{color:C.bd}},
-            y:{stacked:true,ticks:{color:C.m,stepSize:1},grid:{color:C.bd},beginAtZero:true}
-          }
-        }
-      });
+    let totalBuilds = 0, totalFailures = 0, totalJobs = 0;
+    for (const p of pipelines) {
+      const d = data[p];
+      if (!d) continue;
+      totalBuilds += d.summary?.total_builds || 0;
+      totalFailures += d.summary?.jobs_with_failures || 0;
+      totalJobs += d.summary?.total_jobs_tracked || 0;
     }
 
-    // Recent builds table with job matrix
-    if (d.builds?.length) {
-      const section = h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'20px',marginBottom:'20px'}});
-      section.append(h('h3',{text:`Recent Builds`,style:{marginBottom:'12px',fontSize:'14px'}}));
+    summaryRow.append(metricCard('Total Nightly Builds', totalBuilds, `Across ${pipelines.length} pipelines`, C.b));
+    summaryRow.append(metricCard('Jobs with Failures', totalFailures, `of ${totalJobs} tracked`, totalFailures > 0 ? C.r : C.g));
 
-      // Get unique job names across builds for columns
-      const jobNames = new Set();
-      d.builds.slice(0,20).forEach(b => b.jobs?.forEach(j => jobNames.add(j.name)));
-      const sortedJobs = [...jobNames].sort();
-      const showJobs = sortedJobs.length <= 40; // Only show matrix if not too many jobs
+    const topFails = [];
+    const topDurs = [];
+    for (const p of pipelines) {
+      const d = data[p];
+      if (d?.failure_ranking?.[0]) topFails.push({...d.failure_ranking[0], pipeline: p});
+      if (d?.duration_ranking?.[0]) topDurs.push({...d.duration_ranking[0], pipeline: p});
+    }
+    topFails.sort((a,b) => b.fail_rate - a.fail_rate);
+    topDurs.sort((a,b) => (b.median_dur||0) - (a.median_dur||0));
 
-      const tbl = h('table',{style:{width:'100%',borderCollapse:'collapse',fontSize:'12px',overflowX:'auto',display:'block'}});
-      const thead = h('thead');
-      const headerRow = h('tr');
-      headerRow.append(h('th',{text:'Date',style:thS()}));
-      headerRow.append(h('th',{text:'Author',style:thS()}));
-      headerRow.append(h('th',{text:'Status',style:thS('center')}));
-      headerRow.append(h('th',{text:'Message',style:{...thS(),maxWidth:'200px'}}));
-      if (showJobs) {
-        for (const jn of sortedJobs.slice(0,30)) {
-          const th = h('th',{style:{...thS('center'),writingMode:'vertical-lr',transform:'rotate(180deg)',maxHeight:'120px',padding:'4px 2px',fontSize:'9px'}});
-          th.textContent = jn.length > 25 ? jn.slice(0,22)+'...' : jn;
-          th.title = jn;
-          headerRow.append(th);
+    summaryRow.append(metricCard('Worst Failure Rate', topFails[0] ? `${topFails[0].fail_rate}%` : '0%', topFails[0]?.name?.slice(0,30) || '', C.r));
+    summaryRow.append(metricCard('Slowest Job (p50)', topDurs[0] ? fmtDur(topDurs[0].median_dur) : '-', topDurs[0]?.name?.slice(0,30) || '', C.o));
+    box.append(summaryRow);
+
+    // Side-by-side pipeline columns
+    const grid = h('div',{style:{display:'grid',gridTemplateColumns:`repeat(${pipelines.length},1fr)`,gap:'20px',marginBottom:'20px'}});
+
+    for (const p of pipelines) {
+      const d = data[p];
+      if (!d) continue;
+      const col = h('div');
+      col.append(h('h3',{text:d.display_name || p,style:{marginBottom:'12px',color:C.b,borderBottom:`2px solid ${C.b}`,paddingBottom:'6px',fontSize:'14px',fontWeight:'700'}}));
+
+      const s = d.summary;
+      const miniRow = h('div',{style:{display:'grid',gridTemplateColumns:'1fr 1fr',gap:'8px',marginBottom:'16px'}});
+      miniRow.append(metricCard('Builds', s.total_builds, '', C.b));
+      miniRow.append(metricCard('Failures', s.jobs_with_failures, `of ${s.total_jobs_tracked}`, s.jobs_with_failures > 0 ? C.r : C.g));
+      col.append(miniRow);
+
+      // Failure ranking (top 5)
+      if (d.failure_ranking?.length) {
+        const sec = h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'12px',marginBottom:'12px'}});
+        sec.append(h('div',{text:'Top Failures',style:{fontSize:'12px',fontWeight:'700',color:C.m,textTransform:'uppercase',marginBottom:'8px'}}));
+        for (const j of d.failure_ranking.slice(0,5)) {
+          const row = h('div',{style:{display:'flex',justifyContent:'space-between',alignItems:'center',padding:'4px 0',fontSize:'12px'}});
+          row.append(h('span',{text:j.name.length > 30 ? j.name.slice(0,27)+'...' : j.name, title:j.name, style:{overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap',flex:'1',marginRight:'8px'}}));
+          row.append(progressBar(j.fail_rate, 100, j.fail_rate >= 50 ? C.r : j.fail_rate >= 20 ? C.o : C.y, '80px'));
+          sec.append(row);
         }
+        col.append(sec);
       }
-      thead.append(headerRow);
-      tbl.append(thead);
 
-      const tbody = h('tbody');
-      for (const b of d.builds.slice(0,20)) {
-        const tr = h('tr');
-        const dateStr = b.created_at ? new Date(b.created_at).toLocaleDateString('en-US',{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}) : '';
-        tr.append(h('td',{style:tdS()},[
-          h('a',{text:dateStr,href:b.web_url,target:'_blank',style:{color:C.b}})
-        ]));
-        tr.append(h('td',{text:b.author||'',style:{...tdS(),maxWidth:'100px',overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap'}}));
-        tr.append(h('td',{style:tdS('center')},[stateDot(b.state)]));
-        tr.append(h('td',{text:b.message||'',style:{...tdS(),maxWidth:'200px',overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap'},title:b.message||''}));
+      // Duration ranking (top 5)
+      if (d.duration_ranking?.length) {
+        const sec = h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'12px'}});
+        sec.append(h('div',{text:'Slowest Jobs',style:{fontSize:'12px',fontWeight:'700',color:C.m,textTransform:'uppercase',marginBottom:'8px'}}));
+        const maxDur = d.duration_ranking[0]?.median_dur || 1;
+        for (const j of d.duration_ranking.slice(0,5)) {
+          const row = h('div',{style:{display:'flex',justifyContent:'space-between',alignItems:'center',padding:'4px 0',fontSize:'12px'}});
+          row.append(h('span',{text:j.name.length > 30 ? j.name.slice(0,27)+'...' : j.name, title:j.name, style:{overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap',flex:'1',marginRight:'8px'}}));
+          row.append(h('span',{text:fmtDur(j.median_dur),style:{color:C.o,fontWeight:'600',minWidth:'50px',textAlign:'right'}}));
+          sec.append(row);
+        }
+        col.append(sec);
+      }
 
-        if (showJobs) {
-          const jobMap = {};
-          (b.jobs||[]).forEach(j => jobMap[j.name] = j.state);
-          for (const jn of sortedJobs.slice(0,30)) {
-            const st = jobMap[jn];
-            tr.append(h('td',{style:{...tdS('center'),padding:'4px 2px'}},[
-              st ? stateDot(st,'8px') : h('span',{text:'·',style:{color:C.bd}})
-            ]));
+      grid.append(col);
+    }
+    box.append(grid);
+
+    // Daily pass/fail chart (combined)
+    for (const p of pipelines) {
+      const d = data[p];
+      if (d?.daily_stats?.length > 1) {
+        const section = h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'20px',marginBottom:'16px'}});
+        section.append(h('h3',{text:`${d.display_name || p} — Build Pass/Fail`,style:{marginBottom:'12px',fontSize:'14px'}}));
+        const canvas = h('canvas',{style:{maxHeight:'180px'}});
+        section.append(canvas);
+        box.append(section);
+
+        new Chart(canvas, {
+          type: 'bar',
+          data: {
+            labels: d.daily_stats.map(x => x.date.slice(5)),
+            datasets: [
+              {label:'passed',data:d.daily_stats.map(x=>x.passed),backgroundColor:C.g,borderRadius:2},
+              {label:'failed',data:d.daily_stats.map(x=>x.failed),backgroundColor:C.r,borderRadius:2},
+            ]
+          },
+          options: {
+            responsive:true, plugins:{legend:{labels:{color:C.t,font:{size:11}}}},
+            scales:{
+              x:{stacked:true,ticks:{color:C.m,font:{size:10}},grid:{color:C.bd}},
+              y:{stacked:true,ticks:{color:C.m,stepSize:1},grid:{color:C.bd},beginAtZero:true}
+            }
           }
-        }
-        tbody.append(tr);
+        });
       }
-      tbl.append(tbody);
-      section.append(h('div',{style:{overflowX:'auto'}},[tbl]));
-      box.append(section);
     }
   }
 
-  // ═══════════ JOBS VIEW ═══════════
+  // ═══════════ QUEUE COMPARISON VIEW ═══════════
 
-  function renderJobsView(box, data, pipeline) {
-    const d = data[pipeline]; if (!d) return;
-    const s = d.summary;
-
-    const row = h('div',{style:{display:'grid',gridTemplateColumns:'repeat(4,1fr)',gap:'12px',marginBottom:'20px'}});
-    row.append(metricCard('Jobs with Failures', s.jobs_with_failures, '', s.jobs_with_failures>0?C.r:C.g));
-
-    // Find highest fail rate
-    const topFail = d.failure_ranking?.[0];
-    row.append(metricCard('Highest Failure Rate', topFail ? topFail.fail_rate+'%' : '0%', topFail?.name||'', C.r));
-
-    // Find slowest job
-    const topDur = d.duration_ranking?.[0];
-    row.append(metricCard('Slowest Job (p50)', topDur ? fmtDur(topDur.median_dur) : '-', topDur?.name||'', C.o));
-    row.append(metricCard('Total Jobs Tracked', s.total_jobs_tracked, '', C.b));
-    box.append(row);
-
-    // Sub-tabs: Failure Ranking / Duration Ranking
-    const tabBar = h('div',{style:{display:'flex',gap:'0',marginBottom:'16px',borderBottom:`1px solid ${C.bd}`}});
-    const failTab = h('button',{text:'Failure Ranking',style:{background:'transparent',border:'none',borderBottom:`2px solid ${C.b}`,color:C.t,padding:'8px 16px',cursor:'pointer',fontSize:'13px',fontWeight:'600',fontFamily:'inherit'}});
-    const durTab = h('button',{text:'Duration Ranking',style:{background:'transparent',border:'none',borderBottom:'2px solid transparent',color:C.m,padding:'8px 16px',cursor:'pointer',fontSize:'13px',fontWeight:'400',fontFamily:'inherit'}});
-    tabBar.append(failTab, durTab);
-    box.append(tabBar);
-
-    const failContent = h('div');
-    const durContent = h('div',{style:{display:'none'}});
-
-    failTab.onclick = () => { failContent.style.display=''; durContent.style.display='none'; failTab.style.borderBottomColor=C.b; failTab.style.fontWeight='600'; failTab.style.color=C.t; durTab.style.borderBottomColor='transparent'; durTab.style.fontWeight='400'; durTab.style.color=C.m; };
-    durTab.onclick = () => { durContent.style.display=''; failContent.style.display='none'; durTab.style.borderBottomColor=C.b; durTab.style.fontWeight='600'; durTab.style.color=C.t; failTab.style.borderBottomColor='transparent'; failTab.style.fontWeight='400'; failTab.style.color=C.m; };
-
-    // Failure ranking table
-    renderRankingTable(failContent, d.failure_ranking||[], 'failure');
-    renderRankingTable(durContent, d.duration_ranking||[], 'duration');
-
-    box.append(failContent, durContent);
+  function isAmdQueue(name) {
+    return name.startsWith('amd_') || name.startsWith('amd-');
   }
 
-  function renderRankingTable(box, ranking, mode) {
-    if (!ranking.length) { box.append(h('p',{text:'No data.',style:{color:C.m}})); return; }
+  function isNvidiaQueue(name) {
+    return ['gpu_1_queue','gpu_4_queue','B200','H200','a100_queue','mithril-h100-pool','nebius-h200','perf-B200','perf-h200'].includes(name);
+  }
 
-    const INITIAL = 10;
-    const section = h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'20px',marginBottom:'20px'}});
-    const tbl = h('table',{style:{width:'100%',borderCollapse:'collapse',fontSize:'13px'}});
-    const thead = h('thead');
-    const hr = h('tr');
-    hr.append(h('th',{text:'#',style:{...thS('center'),width:'30px'}}));
-    hr.append(h('th',{text:'Job',style:thS()}));
-    if (mode === 'failure') {
-      hr.append(h('th',{text:'Failure Rate',style:thS()}));
-      hr.append(h('th',{text:'Failures',style:thS('center')}));
-      hr.append(h('th',{text:'Passes',style:thS('center')}));
-      hr.append(h('th',{text:'Total Runs',style:thS('center')}));
-    } else {
-      hr.append(h('th',{text:'Median (p50)',style:thS()}));
-      hr.append(h('th',{text:'p90',style:thS('center')}));
-      hr.append(h('th',{text:'Avg',style:thS('center')}));
-      hr.append(h('th',{text:'Max',style:thS('center')}));
-      hr.append(h('th',{text:'Runs',style:thS('center')}));
-    }
-    thead.append(hr);
-    tbl.append(thead);
+  function renderQueueComparison(box, data, pipelines) {
+    // Collect all queues from all pipelines
+    const amdQueues = [];
+    const otherQueues = [];
 
-    const tbody = h('tbody');
-    ranking.forEach((j, i) => {
-      const tr = h('tr',{style: i >= INITIAL ? {display:'none'} : {}});
-      tr.dataset.idx = i;
-      tr.append(h('td',{text:String(i+1),style:{...tdS('center'),color:C.m}}));
-
-      // Job name with optional badges
-      const nameCell = h('td',{style:tdS()});
-      nameCell.append(h('span',{text:j.name}));
-      if (j.is_soft_fail) nameCell.append(h('span',{text:'soft fail',style:{background:C.sf,color:'#fff',padding:'1px 6px',borderRadius:'3px',fontSize:'10px',marginLeft:'6px'}}));
-      tr.append(nameCell);
-
-      if (mode === 'failure') {
-        // Failure rate bar
-        const barColor = j.fail_rate >= 80 ? C.r : j.fail_rate >= 40 ? C.o : j.fail_rate >= 10 ? C.y : C.m;
-        tr.append(h('td',{style:tdS()},[progressBar(j.fail_rate, 100, barColor, '150px')]));
-        tr.append(h('td',{text:String(j.failed + (j.soft_failed||0)),style:{...tdS('center'),color:C.r,fontWeight:'600'}}));
-        tr.append(h('td',{text:String(j.passed),style:{...tdS('center'),color:C.g}}));
-        tr.append(h('td',{text:String(j.runs),style:tdS('center')}));
-      } else {
-        // Duration bar (relative to max)
-        const maxDur = ranking[0]?.median_dur || 1;
-        tr.append(h('td',{style:tdS()},[
-          progressBar(j.median_dur||0, maxDur, C.b, '150px'),
-          h('span',{text:fmtDur(j.median_dur),style:{marginLeft:'8px',fontSize:'12px',color:C.t}})
-        ]));
-        tr.append(h('td',{text:fmtDur(j.p90_dur),style:tdS('center')}));
-        tr.append(h('td',{text:fmtDur(j.avg_dur),style:tdS('center')}));
-        tr.append(h('td',{text:fmtDur(j.max_dur),style:tdS('center')}));
-        tr.append(h('td',{text:String(j.runs),style:tdS('center')}));
+    for (const p of pipelines) {
+      const d = data[p];
+      if (!d?.queue_stats) continue;
+      for (const q of d.queue_stats) {
+        // AMD queues should only come from amd-ci pipeline, not upstream
+        if (isAmdQueue(q.queue)) {
+          if (p.includes('amd')) amdQueues.push({...q, pipeline: p});
+        } else {
+          otherQueues.push({...q, pipeline: p});
+        }
       }
-      tbody.append(tr);
+    }
+
+    // Sort other queues: NVIDIA first, then CPU, then rest
+    otherQueues.sort((a,b) => {
+      const aNv = isNvidiaQueue(a.queue) ? 0 : 1;
+      const bNv = isNvidiaQueue(b.queue) ? 0 : 1;
+      if (aNv !== bNv) return aNv - bNv;
+      return (b.median_wait||0) - (a.median_wait||0);
     });
-    tbl.append(tbody);
-    section.append(tbl);
-    if (ranking.length > INITIAL) {
-      const btn = h('button',{text:`Show all ${ranking.length} jobs`,style:{background:C.bd,border:'none',color:C.t,padding:'6px 16px',borderRadius:'4px',cursor:'pointer',fontSize:'12px',marginTop:'8px',fontFamily:'inherit'}});
-      btn.onclick = () => { tbody.querySelectorAll('tr').forEach(r => r.style.display = ''); btn.remove(); };
-      section.append(btn);
-    }
-    box.append(section);
+
+    amdQueues.sort((a,b) => (b.median_wait||0) - (a.median_wait||0));
+
+    // Summary metrics
+    const totalAmdJobs = amdQueues.reduce((a,q) => a + q.jobs, 0);
+    const totalOtherJobs = otherQueues.reduce((a,q) => a + q.jobs, 0);
+    const topAmdWait = amdQueues[0];
+    const topOtherWait = otherQueues[0];
+
+    const summaryRow = h('div',{style:{display:'grid',gridTemplateColumns:'repeat(4,1fr)',gap:'12px',marginBottom:'20px'}});
+    summaryRow.append(metricCard('AMD Queue Jobs', totalAmdJobs.toLocaleString(), `${amdQueues.length} queues`, C.r));
+    summaryRow.append(metricCard('Other Agent Jobs', totalOtherJobs.toLocaleString(), `${otherQueues.length} queues`, C.b));
+    summaryRow.append(metricCard('AMD Longest Wait', fmtDur(topAmdWait?.median_wait), topAmdWait?.queue||'', C.o));
+    summaryRow.append(metricCard('Other Longest Wait', fmtDur(topOtherWait?.median_wait), topOtherWait?.queue||'', C.o));
+    box.append(summaryRow);
+
+    // Two-column layout
+    const grid = h('div',{style:{display:'grid',gridTemplateColumns:'1fr 1fr',gap:'20px'}});
+
+    // AMD column
+    const amdCol = h('div');
+    amdCol.append(h('h3',{text:'AMD Queues',style:{marginBottom:'12px',color:C.r,borderBottom:`2px solid ${C.r}`,paddingBottom:'6px',fontSize:'14px',fontWeight:'700'}}));
+    renderQueueTable(amdCol, amdQueues);
+    grid.append(amdCol);
+
+    // Other agents column (NVIDIA on top)
+    const otherCol = h('div');
+    otherCol.append(h('h3',{text:'Other Agents',style:{marginBottom:'12px',color:C.b,borderBottom:`2px solid ${C.b}`,paddingBottom:'6px',fontSize:'14px',fontWeight:'700'}}));
+    renderQueueTable(otherCol, otherQueues);
+    grid.append(otherCol);
+
+    box.append(grid);
   }
 
-  // ═══════════ QUEUE VIEW ═══════════
+  function renderQueueTable(box, queues) {
+    if (!queues.length) { box.append(h('p',{text:'No queue data.',style:{color:C.m,fontSize:'13px'}})); return; }
 
-  function renderQueueView(box, data, pipeline) {
-    const d = data[pipeline]; if (!d) return;
-    const qs = d.queue_stats || [];
-    if (!qs.length) { box.append(h('p',{text:'No queue data.',style:{color:C.m}})); return; }
-
-    const topWait = qs[0];
-    const totalJobs = qs.reduce((a,q) => a + q.jobs, 0);
-
-    const row = h('div',{style:{display:'grid',gridTemplateColumns:'repeat(4,1fr)',gap:'12px',marginBottom:'20px'}});
-    row.append(metricCard('Total Jobs', totalJobs.toLocaleString(), '', C.b));
-    row.append(metricCard('Longest p50 Wait', fmtDur(topWait?.median_wait), topWait?.queue||'', C.r));
-    row.append(metricCard('Longest p90 Wait', fmtDur(topWait?.p90_wait), topWait?.queue||'', C.o));
-    row.append(metricCard('Queues Active', qs.length, '', C.b));
-    box.append(row);
-
-    // Queue ranking table
-    const section = h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'20px',marginBottom:'20px'}});
-    section.append(h('h3',{text:'Queue Wait Time Ranking',style:{marginBottom:'12px',fontSize:'14px'}}));
-
-    const tbl = h('table',{style:{width:'100%',borderCollapse:'collapse',fontSize:'13px'}});
+    const section = h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'16px'}});
+    const tbl = h('table',{style:{width:'100%',borderCollapse:'collapse',fontSize:'12px'}});
     const thead = h('thead');
     const hr = h('tr');
-    hr.append(h('th',{text:'#',style:{...thS('center'),width:'30px'}}));
     hr.append(h('th',{text:'Queue',style:thS()}));
-    hr.append(h('th',{text:'p50 Wait',style:thS()}));
-    hr.append(h('th',{text:'p90 Wait',style:thS('center')}));
-    hr.append(h('th',{text:'Avg Wait',style:thS('center')}));
-    hr.append(h('th',{text:'Max Wait',style:thS('center')}));
+    hr.append(h('th',{text:'p50',style:thS('center')}));
+    hr.append(h('th',{text:'p90',style:thS('center')}));
     hr.append(h('th',{text:'Jobs',style:thS('center')}));
     thead.append(hr);
     tbl.append(thead);
 
     const tbody = h('tbody');
-    const maxWait = qs[0]?.median_wait || 1;
-    qs.forEach((q, i) => {
+    const maxWait = queues[0]?.median_wait || 1;
+    for (const q of queues) {
       const tr = h('tr');
-      tr.append(h('td',{text:String(i+1),style:{...tdS('center'),color:C.m}}));
-      tr.append(h('td',{text:q.queue,style:{...tdS(),fontWeight:'600'}}));
+      const isNv = isNvidiaQueue(q.queue);
+      const labelColor = isAmdQueue(q.queue) ? C.r : isNv ? '#76b900' : C.m;
+      tr.append(h('td',{style:{...tdS(),fontWeight:'600'}},[
+        h('span',{style:{width:'6px',height:'6px',borderRadius:'50%',background:labelColor,display:'inline-block',marginRight:'6px'}}),
+        q.queue
+      ]));
 
       const wColor = (q.median_wait||0) > 10 ? C.r : (q.median_wait||0) > 5 ? C.o : (q.median_wait||0) > 2 ? C.y : C.g;
-      tr.append(h('td',{style:tdS()},[
-        progressBar(q.median_wait||0, maxWait, wColor, '120px'),
-        h('span',{text:fmtDur(q.median_wait),style:{marginLeft:'8px',fontSize:'12px'}})
-      ]));
+      tr.append(h('td',{text:fmtDur(q.median_wait),style:{...tdS('center'),color:wColor,fontWeight:'600'}}));
       tr.append(h('td',{text:fmtDur(q.p90_wait),style:tdS('center')}));
-      tr.append(h('td',{text:fmtDur(q.avg_wait),style:tdS('center')}));
-      tr.append(h('td',{text:fmtDur(q.max_wait),style:tdS('center')}));
       tr.append(h('td',{text:q.jobs.toLocaleString(),style:tdS('center')}));
       tbody.append(tr);
-    });
+    }
     tbl.append(tbody);
     section.append(tbl);
     box.append(section);
@@ -329,109 +276,45 @@
     container.innerHTML = '';
 
     const pipelines = Object.keys(data);
-    let activeProject = 'vllm';
-    let activePipeline = pipelines[0] || 'amd-ci';
-    let activeView = 'builds';
+    if (!pipelines.length) {
+      container.append(h('div',{style:{textAlign:'center',padding:'60px 20px',color:C.m}},[
+        h('h3',{text:'CI Analytics',style:{marginBottom:'8px'}}),
+        h('p',{text:'No analytics data available yet.'}),
+      ]));
+      return;
+    }
 
-    // All projects for selector
-    const allProjects = ['vllm','pytorch','jax','triton','sglang','xla'];
+    let activeView = 'comparison';
 
     // Title
     container.append(h('h2',{text:'CI Analytics',style:{marginBottom:'4px'}}));
+    container.append(h('p',{text:'Nightly builds only',style:{color:C.m,fontSize:'12px',marginBottom:'16px',fontStyle:'italic'}}));
 
-    // Project selector bar
-    const projBar = h('div',{style:{display:'flex',gap:'4px',marginBottom:'16px',borderBottom:`1px solid ${C.bd}`,paddingBottom:'8px',overflowX:'auto'}});
-    const projBtns = {};
-    const contentWrapper = h('div');
-
-    for (const p of allProjects) {
-      const active = p === 'vllm';
-      const btn = h('button',{text:p,style:{background:active?C.b:'transparent',border:'none',color:C.t,padding:'6px 16px',borderRadius:'6px 6px 0 0',cursor:'pointer',fontSize:'13px',fontWeight:active?'700':'400',fontFamily:'inherit',borderBottom:active?`2px solid ${C.b}`:'2px solid transparent'}});
-      btn.onclick = () => {
-        activeProject = p;
-        projBar.querySelectorAll('button').forEach(b => { b.style.background='transparent'; b.style.borderBottomColor='transparent'; b.style.fontWeight='400'; });
-        btn.style.background = C.b; btn.style.borderBottomColor = C.b; btn.style.fontWeight = '700';
-        renderProjectContent();
-      };
-      projBtns[p] = btn;
-      projBar.append(btn);
-    }
-    container.append(projBar);
-
-    function renderProjectContent() {
-      contentWrapper.innerHTML = '';
-      if (activeProject !== 'vllm' || !pipelines.length) {
-        contentWrapper.append(h('div',{style:{textAlign:'center',padding:'60px 20px',color:C.m}},[
-          h('h3',{text:activeProject,style:{marginBottom:'8px'}}),
-          h('p',{text:'CI analytics not yet configured for this project.'}),
-          h('p',{text:'To add: create scripts/' + activeProject + '/collect_analytics.py',style:{fontSize:'12px',marginTop:'8px'}}),
-        ]));
-        return;
-      }
-      renderVllmAnalytics(contentWrapper);
-    }
-
-    function renderVllmAnalytics(box) {
-    // Pipeline selector + View tabs
-    const controls = h('div',{style:{display:'flex',justifyContent:'space-between',alignItems:'center',marginBottom:'20px',flexWrap:'wrap',gap:'8px'}});
-
-    // Pipeline dropdown with "Compare" option
-    const pipelineRow = h('div',{style:{display:'flex',alignItems:'center',gap:'8px'}});
-    pipelineRow.append(h('span',{text:'Pipeline',style:{color:C.m,fontSize:'12px'}}));
-    const pipelineSelect = h('select',{style:{background:C.bg,color:C.t,border:`1px solid ${C.bd}`,borderRadius:'4px',padding:'6px 12px',fontSize:'13px',fontFamily:'inherit',cursor:'pointer'}});
-    for (const p of pipelines) {
-      const opt = h('option',{value:p,text:data[p]?.display_name || p});
-      if (p === activePipeline) opt.selected = true;
-      pipelineSelect.append(opt);
-    }
-    if (pipelines.length > 1) {
-      const cmpOpt = h('option',{value:'__compare__',text:'Compare (Side-by-Side)'});
-      pipelineSelect.append(cmpOpt);
-    }
-    pipelineRow.append(pipelineSelect);
-    pipelineRow.append(h('span',{text:'Nightly builds only',style:{color:C.m,fontSize:'11px',fontStyle:'italic'}}));
-    controls.append(pipelineRow);
-
-    // View tabs
-    const viewTabs = h('div',{style:{display:'flex',gap:'0',borderBottom:`1px solid ${C.bd}`}});
-    const views = [{id:'builds',label:'Builds'},{id:'jobs',label:'Jobs'},{id:'queue',label:'Queue'}];
+    // View tabs: Comparison | Queue Comparison
+    const viewTabs = h('div',{style:{display:'flex',gap:'0',marginBottom:'20px',borderBottom:`1px solid ${C.bd}`}});
+    const views = [{id:'comparison',label:'Pipeline Comparison'},{id:'queue',label:'Queue Comparison'}];
     const tabBtns = {};
     for (const v of views) {
-      const btn = h('button',{text:v.label,style:{background:'transparent',border:'none',borderBottom:v.id==='builds'?`2px solid ${C.b}`:'2px solid transparent',color:v.id==='builds'?C.t:C.m,padding:'8px 16px',cursor:'pointer',fontSize:'13px',fontWeight:v.id==='builds'?'600':'400',fontFamily:'inherit'}});
+      const isActive = v.id === 'comparison';
+      const btn = h('button',{text:v.label,style:{background:'transparent',border:'none',borderBottom:isActive?`2px solid ${C.b}`:'2px solid transparent',color:isActive?C.t:C.m,padding:'8px 16px',cursor:'pointer',fontSize:'13px',fontWeight:isActive?'600':'400',fontFamily:'inherit',transition:'all 0.2s'}});
       btn.dataset.view = v.id;
       tabBtns[v.id] = btn;
       viewTabs.append(btn);
     }
-    controls.append(viewTabs);
-    box.append(controls);
+    container.append(viewTabs);
 
-    // Content area
     const content = h('div');
-    box.append(content);
+    container.append(content);
 
     function renderContent() {
       content.innerHTML = '';
-      if (activePipeline === '__compare__') {
-        // Side-by-side comparison
-        const grid = h('div',{style:{display:'grid',gridTemplateColumns:'1fr 1fr',gap:'20px'}});
-        for (const p of pipelines) {
-          const col = h('div');
-          col.append(h('h3',{text:data[p]?.display_name || p,style:{marginBottom:'12px',color:C.b,borderBottom:`2px solid ${C.b}`,paddingBottom:'6px'}}));
-          if (activeView === 'builds') renderBuildsView(col, data, p);
-          else if (activeView === 'jobs') renderJobsView(col, data, p);
-          else if (activeView === 'queue') renderQueueView(col, data, p);
-          grid.append(col);
-        }
-        content.append(grid);
+      if (activeView === 'comparison') {
+        renderComparisonView(content, data, pipelines);
       } else {
-        if (activeView === 'builds') renderBuildsView(content, data, activePipeline);
-        else if (activeView === 'jobs') renderJobsView(content, data, activePipeline);
-        else if (activeView === 'queue') renderQueueView(content, data, activePipeline);
+        renderQueueComparison(content, data, pipelines);
       }
     }
 
-    // Event handlers
-    pipelineSelect.onchange = () => { activePipeline = pipelineSelect.value; renderContent(); };
     for (const v of views) {
       tabBtns[v.id].onclick = () => {
         activeView = v.id;
@@ -445,10 +328,6 @@
     }
 
     renderContent();
-    } // end renderVllmAnalytics
-
-    container.append(contentWrapper);
-    renderProjectContent();
   }
 
   // Lazy load

--- a/docs/assets/js/ci-analytics.js
+++ b/docs/assets/js/ci-analytics.js
@@ -232,8 +232,10 @@
   function renderQueueTable(box, queues) {
     if (!queues.length) { box.append(h('p',{text:'No queue data.',style:{color:C.m,fontSize:'13px'}})); return; }
 
+    const BK_QUEUES_URL = 'https://buildkite.com/organizations/vllm/clusters/9cecc6b1-94cd-43d1-a256-ab438083f4f5/queues';
+
     const section = h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'16px'}});
-    const tbl = h('table',{style:{width:'100%',borderCollapse:'collapse',fontSize:'12px'}});
+    const tbl = h('table',{style:{width:'100%',borderCollapse:'collapse',fontSize:'13px'}});
     const thead = h('thead');
     const hr = h('tr');
     hr.append(h('th',{text:'Queue',style:thS()}));
@@ -248,11 +250,15 @@
     for (const q of queues) {
       const tr = h('tr');
       const isNv = isNvidiaQueue(q.queue);
-      const labelColor = isAmdQueue(q.queue) ? C.r : isNv ? '#76b900' : C.m;
-      tr.append(h('td',{style:{...tdS(),fontWeight:'600'}},[
-        h('span',{style:{width:'6px',height:'6px',borderRadius:'50%',background:labelColor,display:'inline-block',marginRight:'6px'}}),
-        q.queue
-      ]));
+      const labelColor = isAmdQueue(q.queue) ? C.r : isNv ? C.b : C.m;
+      // Queue name as clickable link to Buildkite
+      const nameCell = h('td',{style:{...tdS(),fontWeight:'600'}});
+      nameCell.append(h('span',{style:{width:'6px',height:'6px',borderRadius:'50%',background:labelColor,display:'inline-block',marginRight:'6px'}}));
+      const qLink = h('a',{text:q.queue,href:BK_QUEUES_URL,target:'_blank',style:{color:C.t,textDecoration:'none'}});
+      qLink.onmouseenter = () => { qLink.style.color = C.b; qLink.style.textDecoration = 'underline'; };
+      qLink.onmouseleave = () => { qLink.style.color = C.t; qLink.style.textDecoration = 'none'; };
+      nameCell.append(qLink);
+      tr.append(nameCell);
 
       const wColor = (q.median_wait||0) > 10 ? C.r : (q.median_wait||0) > 5 ? C.o : (q.median_wait||0) > 2 ? C.y : C.g;
       tr.append(h('td',{text:fmtDur(q.median_wait),style:{...tdS('center'),color:wColor,fontWeight:'600'}}));

--- a/docs/assets/js/ci-analytics.js
+++ b/docs/assets/js/ci-analytics.js
@@ -271,6 +271,143 @@
     box.append(section);
   }
 
+  // ═══════════ RECENT BUILDS MATRIX ═══════════
+
+  function normalizeJobName(name) {
+    // Normalize to base group: strip shard suffixes, hardware tags, GPU counts
+    var n = name.replace(/\s*\(H100[-–]MI\d+\)\s*/gi, '');
+    n = n.replace(/\s*\(MI\d+\)\s*/gi, '');
+    n = n.replace(/\s+%\d+$/, '');
+    // Strip trailing shard numbers
+    n = n.replace(/\s+\d+$/, '');
+    n = n.replace(/\s+\d+\s*:.*$/, '');
+    n = n.replace(/\s+\d+\)$/, ')');
+    return n.trim();
+  }
+
+  function renderBuildsMatrix(box, data, pipelines) {
+    // Pipeline selector
+    const pipeRow = h('div',{style:{display:'flex',gap:'8px',alignItems:'center',marginBottom:'16px'}});
+    pipeRow.append(h('span',{text:'Pipeline:',style:{color:C.m,fontSize:'13px'}}));
+    let activePipe = pipelines[0] || 'amd-ci';
+
+    for (const p of pipelines) {
+      const btn = h('button',{text:data[p]?.display_name || p,style:{
+        background:p===activePipe?C.b:'transparent',border:'none',color:C.t,
+        padding:'6px 14px',borderRadius:'4px',cursor:'pointer',fontSize:'13px',fontFamily:'inherit',
+        fontWeight:p===activePipe?'700':'400',transition:'all 0.15s'
+      }});
+      btn.onclick = () => {
+        activePipe = p;
+        pipeRow.querySelectorAll('button').forEach(b => { b.style.background='transparent'; b.style.fontWeight='400'; });
+        btn.style.background = C.b; btn.style.fontWeight = '700';
+        matrixBox.innerHTML = '';
+        renderMatrix(matrixBox, data[p]);
+      };
+      pipeRow.append(btn);
+    }
+    box.append(pipeRow);
+
+    const matrixBox = h('div');
+    box.append(matrixBox);
+    renderMatrix(matrixBox, data[activePipe]);
+  }
+
+  function renderMatrix(box, pipeData) {
+    if (!pipeData?.builds?.length) { box.append(h('p',{text:'No builds.',style:{color:C.m}})); return; }
+    const builds = pipeData.builds.slice(0, 20);
+
+    // Collect all unique normalized job names from the MOST RECENT build
+    // (use latest names as the canonical set)
+    const latestJobs = new Set();
+    const latestBuild = builds[0];
+    (latestBuild.jobs || []).forEach(j => latestJobs.add(normalizeJobName(j.name)));
+
+    // Also check 2nd build for any jobs that might have been renamed
+    if (builds[1]) {
+      (builds[1].jobs || []).forEach(j => latestJobs.add(normalizeJobName(j.name)));
+    }
+
+    const jobNames = [...latestJobs].sort();
+    const showMatrix = jobNames.length <= 60;
+
+    // Section
+    const section = h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'20px',overflowX:'auto'}});
+    section.append(h('h3',{text:`Recent Builds (${pipeData.display_name || ''})`,style:{marginBottom:'16px',fontSize:'16px'}}));
+
+    if (!showMatrix) {
+      section.append(h('p',{text:`Too many jobs (${jobNames.length}) to show matrix. Showing summary only.`,style:{color:C.m,fontSize:'13px',marginBottom:'12px'}}));
+    }
+
+    const tbl = h('table',{style:{width:'100%',borderCollapse:'collapse',fontSize:'12px'}});
+    const thead = h('thead');
+    const headerRow = h('tr');
+    headerRow.append(h('th',{text:'Started',style:{...thS(),position:'sticky',left:0,background:C.bg,zIndex:1}}));
+    headerRow.append(h('th',{text:'Commit',style:thS()}));
+    headerRow.append(h('th',{text:'Status',style:thS('center')}));
+    headerRow.append(h('th',{text:'Message',style:{...thS(),maxWidth:'200px'}}));
+
+    if (showMatrix) {
+      for (const jn of jobNames) {
+        const th = h('th',{style:{...thS('center'),writingMode:'vertical-lr',transform:'rotate(180deg)',maxHeight:'140px',padding:'4px 3px',fontSize:'10px',lineHeight:'1.2'}});
+        th.textContent = jn.length > 28 ? jn.slice(0,25)+'...' : jn;
+        th.title = jn;
+        headerRow.append(th);
+      }
+    }
+    thead.append(headerRow);
+    tbl.append(thead);
+
+    const tbody = h('tbody');
+    for (const b of builds) {
+      const tr = h('tr');
+      const dateStr = b.created_at ? new Date(b.created_at).toLocaleDateString('en-US',{weekday:'short',month:'short',day:'numeric',hour:'numeric',minute:'2-digit'}) : '';
+
+      // Date cell - clickable to Buildkite
+      const dateLink = h('a',{text:dateStr,href:b.web_url||'#',target:'_blank',style:{color:C.b,textDecoration:'none',whiteSpace:'nowrap',fontSize:'12px'}});
+      tr.append(h('td',{style:{...tdS(),position:'sticky',left:0,background:C.bg,zIndex:1}},[dateLink]));
+
+      // Commit (short sha)
+      const sha = b.message ? '' : '';
+      const commitEl = h('td',{style:{...tdS(),fontFamily:'monospace',fontSize:'11px'}});
+      if (b.web_url) {
+        const shaStr = b.web_url.split('/').pop() || '';
+        commitEl.append(h('a',{text:'#' + (b.number || shaStr),href:b.web_url,target:'_blank',style:{color:C.m,textDecoration:'none'}}));
+      }
+      tr.append(commitEl);
+
+      // Status dot
+      tr.append(h('td',{style:tdS('center')},[stateDot(b.state,'12px')]));
+
+      // Message
+      tr.append(h('td',{text:(b.message||'').slice(0,50),style:{...tdS(),maxWidth:'200px',overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap',fontSize:'12px'},title:b.message||''}));
+
+      if (showMatrix) {
+        // Build a map of normalized job name -> best state
+        const jobMap = {};
+        (b.jobs||[]).forEach(j => {
+          const norm = normalizeJobName(j.name);
+          const prev = jobMap[norm];
+          // If multiple jobs map to same normalized name, prioritize: failed > soft_fail > passed > other
+          if (!prev || j.state === 'failed' || (j.state === 'soft_fail' && prev !== 'failed') || (j.state === 'passed' && prev !== 'failed' && prev !== 'soft_fail')) {
+            jobMap[norm] = j.state;
+          }
+        });
+
+        for (const jn of jobNames) {
+          const st = jobMap[jn];
+          tr.append(h('td',{style:{...tdS('center'),padding:'3px 2px'}},[
+            st ? stateDot(st,'9px') : h('span',{text:'',style:{display:'inline-block',width:'9px',height:'9px',borderRadius:'50%',background:C.bd}})
+          ]));
+        }
+      }
+      tbody.append(tr);
+    }
+    tbl.append(tbody);
+    section.append(tbl);
+    box.append(section);
+  }
+
   // ═══════════ MAIN RENDER ═══════════
 
   async function render() {
@@ -298,7 +435,7 @@
 
     // View tabs: Comparison | Queue Comparison
     const viewTabs = h('div',{style:{display:'flex',gap:'0',marginBottom:'20px',borderBottom:`1px solid ${C.bd}`}});
-    const views = [{id:'comparison',label:'Pipeline Comparison'},{id:'queue',label:'Queue Comparison'}];
+    const views = [{id:'comparison',label:'Pipeline Comparison'},{id:'builds',label:'Recent Builds'},{id:'queue',label:'Queue Comparison'}];
     const tabBtns = {};
     for (const v of views) {
       const isActive = v.id === 'comparison';
@@ -316,6 +453,8 @@
       content.innerHTML = '';
       if (activeView === 'comparison') {
         renderComparisonView(content, data, pipelines);
+      } else if (activeView === 'builds') {
+        renderBuildsMatrix(content, data, pipelines);
       } else {
         renderQueueComparison(content, data, pipelines);
       }

--- a/docs/assets/js/ci-health.js
+++ b/docs/assets/js/ci-health.js
@@ -44,37 +44,7 @@
     return s
   }
 
-  // ═══════════════════════ PROJECT SELECTOR ═══════════════════════
-  function renderSelector(box,projects,contentBox) {
-    const nav=h('div',{style:{display:'flex',gap:'4px',marginBottom:'20px',borderBottom:`1px solid ${C.bd}`,paddingBottom:'8px',overflowX:'auto'}});
-    for(const p of projects) {
-      const active=p==='vllm';
-      const btn=h('button',{text:p,style:{background:active?C.b:'transparent',border:'none',color:C.t,padding:'6px 16px',borderRadius:'6px 6px 0 0',cursor:'pointer',fontSize:'13px',fontWeight:active?'700':'400',fontFamily:'inherit',borderBottom:active?`2px solid ${C.b}`:'2px solid transparent'}});
-      btn.onmouseenter=()=>{if(!btn.dataset.active)btn.style.borderBottomColor=C.m};
-      btn.onmouseleave=()=>{if(!btn.dataset.active)btn.style.borderBottomColor='transparent'};
-      if(active) btn.dataset.active='1';
-      btn.onclick=()=>{
-        nav.querySelectorAll('button').forEach(b=>{b.style.background='transparent';b.style.borderBottomColor='transparent';b.style.fontWeight='400';delete b.dataset.active});
-        btn.style.background=C.b;btn.style.borderBottomColor=C.b;btn.style.fontWeight='700';btn.dataset.active='1';
-        if(p==='vllm') {
-          contentBox.style.display='';
-          const placeholder=box.querySelector('.project-placeholder');
-          if(placeholder) placeholder.style.display='none';
-        } else {
-          contentBox.style.display='none';
-          let placeholder=box.querySelector('.project-placeholder');
-          if(!placeholder) {
-            placeholder=h('div',{cls:'project-placeholder',style:{textAlign:'center',padding:'60px 20px',color:C.m}});
-            box.append(placeholder);
-          }
-          placeholder.style.display='';
-          placeholder.innerHTML=`<h3 style="margin-bottom:8px">${p}</h3><p>CI health data collection not yet configured for this project.</p><p style="font-size:12px;margin-top:8px">To add: create <code>scripts/${p}/pipelines.py</code> and run <code>collect_ci.py</code></p>`;
-        }
-      };
-      nav.append(btn);
-    }
-    box.append(nav);
-  }
+  // Project selector removed — handled by sidebar navigation
 
   // ═══════════════════════ METRIC CARDS ROW ═══════════════════════
   function renderMetrics(box,health,parity) {
@@ -106,11 +76,12 @@
       row.append(card('Test Groups',a.test_groups,`${a.jobs_passed||0} jobs passed`,C.b));
     }
 
-    // Parity
+    // Parity (merge sharded groups for correct counting)
     if(parity?.job_groups) {
-      const both=parity.job_groups.filter(g=>g.amd&&g.upstream).length;
-      const aOnly=parity.job_groups.filter(g=>g.amd&&!g.upstream).length;
-      const uOnly=parity.job_groups.filter(g=>!g.amd&&g.upstream).length;
+      const mergedGroups=typeof mergeShardedGroups==='function'?mergeShardedGroups(parity.job_groups):parity.job_groups;
+      const both=mergedGroups.filter(g=>g.amd&&g.upstream).length;
+      const aOnly=mergedGroups.filter(g=>g.amd&&!g.upstream).length;
+      const uOnly=mergedGroups.filter(g=>!g.amd&&g.upstream).length;
       row.append(card('Coverage Parity',`${both} common`,`${aOnly} AMD-only &bull; ${uOnly} upstream-only`,C.p));
     } else if(u) {
       row.append(card('Upstream',pct(u.pass_rate,1),`Build #${u.build_number} &bull; ${u.total_tests.toLocaleString()} tests`,rc(u.pass_rate)));
@@ -119,7 +90,7 @@
     box.append(row);
   }
 
-  // ═══════════════════════ HARDWARE BREAKDOWN ═══════════════════════
+  // ═══════════════════════ HARDWARE BREAKDOWN (consolidated) ═══════════════════════
   function renderHardware(box,health) {
     if(!health?.amd?.latest_build?.by_hardware) return;
     const bh=health.amd.latest_build.by_hardware;
@@ -128,40 +99,43 @@
 
     const hwNames={mi250:'MI250 (gfx90a)',mi325:'MI325 (gfx942)',mi355:'MI355 (gfx950)'};
 
-    box.append(h('h3',{text:'Hardware Breakdown',style:{marginBottom:'12px'}}));
-    const grid=h('div',{style:{display:'grid',gridTemplateColumns:`repeat(${hws.length},1fr)`,gap:'12px',marginBottom:'24px'}});
+    const det=h('details',{open:true,style:{marginBottom:'20px',background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px'}});
+    det.append(h('summary',{text:'Hardware Breakdown',style:{padding:'12px 16px',cursor:'pointer',fontSize:'14px',fontWeight:'600'}}));
+    const inner=h('div',{style:{padding:'0 16px 16px'}});
 
+    // Compact table view
+    const tbl=h('table',{style:{width:'100%',borderCollapse:'collapse',fontSize:'13px'}});
+    tbl.append(h('thead',{},[h('tr',{},[
+      h('th',{text:'Hardware',style:ts()}),
+      h('th',{text:'Pass Rate',style:ts()}),
+      h('th',{text:'Passed',style:ts('center')}),
+      h('th',{text:'Failed',style:ts('center')}),
+      h('th',{text:'Skipped',style:ts('center')}),
+      h('th',{text:'Groups',style:ts('center')}),
+      h('th',{text:'Total Tests',style:ts('center')}),
+    ])]));
+    const tb=h('tbody');
     for(const[hw,c]of hws) {
-      const col=h('div',{style:{background:C.bg,border:`1px solid ${C.bd}`,borderRadius:'8px',padding:'20px',textAlign:'center'}});
-      col.append(h('div',{text:hwNames[hw]||hw.toUpperCase(),style:{fontSize:'14px',fontWeight:'700',marginBottom:'12px'}}));
-      col.append(h('div',{text:pct(c.pass_rate,1),style:{fontSize:'36px',fontWeight:'800',color:rc(c.pass_rate),lineHeight:'1.1'}}));
-      col.append(h('div',{style:{margin:'12px auto',width:'80%'}},[ bar(c.pass_rate,'100%') ]));
-      const stats=h('div',{style:{display:'grid',gridTemplateColumns:'1fr 1fr 1fr',gap:'4px',fontSize:'12px',marginTop:'8px'}});
-      stats.append(h('div',{html:`<span style="color:${C.g};font-weight:700">${c.passed.toLocaleString()}</span><br><span style="color:${C.m}">passed</span>`}));
-      stats.append(h('div',{html:`<span style="color:${C.r};font-weight:700">${c.failed}</span><br><span style="color:${C.m}">failed</span>`}));
-      stats.append(h('div',{html:`<span style="color:${C.m};font-weight:700">${c.skipped.toLocaleString()}</span><br><span style="color:${C.m}">skipped</span>`}));
-      col.append(stats);
-      // Test groups row - prominent
+      const gFail=c.groups_failed||0;
+      const gPass=(c.groups||0)-gFail;
+      const tr=h('tr');
+      tr.append(h('td',{text:hwNames[hw]||hw.toUpperCase(),style:{...td(),fontWeight:'700'}}));
+      tr.append(h('td',{style:td()},[ bar(c.pass_rate,'100px') ]));
+      tr.append(h('td',{text:c.passed.toLocaleString(),style:{...tdo('center'),color:C.g,fontWeight:'600'}}));
+      tr.append(h('td',{text:String(c.failed),style:{...tdo('center'),color:c.failed>0?C.r:C.g,fontWeight:'600'}}));
+      tr.append(h('td',{text:c.skipped.toLocaleString(),style:tdo('center')}));
       if(c.groups) {
-        const gFail=c.groups_failed||0;
-        const gPass=c.groups-gFail;
-        col.append(h('div',{style:{marginTop:'14px',padding:'10px',background:C.bg2,borderRadius:'6px',border:`1px solid ${C.bd}`}},[
-          h('div',{html:`<span style="font-size:22px;font-weight:800;color:${gFail>0?C.y:C.g}">${gPass}/${c.groups}</span>`,style:{textAlign:'center'}}),
-          h('div',{text:'test groups passing',style:{fontSize:'12px',color:C.m,textAlign:'center',marginTop:'2px'}}),
-          ...(gFail>0?[h('div',{text:`${gFail} failing — view details`,style:{fontSize:'13px',color:C.r,textAlign:'center',marginTop:'6px',cursor:'pointer',textDecoration:'underline',fontWeight:'600'},
-            onclick:()=>{
-              // Click the "Regressions" filter button and scroll to parity section
-              const regBtn=document.querySelector('button[data-filter="regression"]');
-              if(regBtn)regBtn.click();
-              const paritySection=document.querySelector('h3[data-parity-title]');
-              if(paritySection)paritySection.scrollIntoView({behavior:'smooth',block:'start'});
-            }})]:[]),
-        ]));
+        tr.append(h('td',{html:`<span style="color:${gFail>0?C.y:C.g};font-weight:700">${gPass}/${c.groups}</span>${gFail>0?' <span style="color:'+C.r+';font-size:11px">('+gFail+' failing)</span>':''}`,style:tdo('center')}));
+      } else {
+        tr.append(h('td',{text:'-',style:tdo('center')}));
       }
-      col.append(h('div',{text:`${c.total.toLocaleString()} total tests`,style:{fontSize:'12px',color:C.m,marginTop:'6px',textAlign:'center'}}));
-      grid.append(col);
+      tr.append(h('td',{text:c.total.toLocaleString(),style:tdo('center')}));
+      tb.append(tr);
     }
-    box.append(grid);
+    tbl.append(tb);
+    inner.append(tbl);
+    det.append(inner);
+    box.append(det);
   }
 
   // ═══════════════════════ TREND CHART ═══════════════════════
@@ -213,7 +187,8 @@
   // ═══════════════════════ HEATMAP ═══════════════════════
   function renderHeatmap(box,parity) {
     if(!parity?.job_groups) return;
-    const groups=parity.job_groups.filter(g=>g.amd&&g.upstream);
+    const allMerged=typeof mergeShardedGroups==='function'?mergeShardedGroups(parity.job_groups):parity.job_groups;
+    const groups=allMerged.filter(g=>g.amd&&g.upstream);
     if(!groups.length) return;
 
     const areas={};
@@ -246,7 +221,7 @@
   // ═══════════════════════ GROUPED PARITY ═══════════════════════
   function renderGroups(box,parity) {
     if(!parity?.job_groups) return;
-    const all=parity.job_groups;
+    const all=typeof mergeShardedGroups==='function'?mergeShardedGroups(parity.job_groups):parity.job_groups;
     const both=all.filter(g=>g.amd&&g.upstream);
     const aOnly=all.filter(g=>g.amd&&!g.upstream);
     const uOnly=all.filter(g=>!g.amd&&g.upstream);
@@ -567,26 +542,20 @@
     if(!health&&!parity&&!eng){box.innerHTML='<p style="color:#8b949e">No data. Run collect_ci.py.</p>';return}
     box.innerHTML='';
 
-    // Content wrapper (hidden/shown by project selector)
-    const content=h('div');
-
-    // Project selector
-    renderSelector(box,['vllm','pytorch','jax','triton','sglang','xla'],content);
+    box.append(h('h2',{text:'CI Health',style:{marginBottom:'4px'}}));
 
     if(health?.generated_at)
-      content.append(h('p',{text:`Last updated: ${new Date(health.generated_at).toLocaleString()}`,style:{color:C.m,fontSize:'12px',marginBottom:'16px'}}));
+      box.append(h('p',{text:`Last updated: ${new Date(health.generated_at).toLocaleString()}`,style:{color:C.m,fontSize:'12px',marginBottom:'16px'}}));
 
-    renderMetrics(content,health,parity);
-    renderHardware(content,health);
-    renderTrend(content,health);
-    // renderHealthBar removed — confusing with only 1 day of data
-    renderHeatmap(content,parity);
-    renderGroups(content,parity);
-    renderFlaky(content,flaky);
-    renderOffenders(content,trends);
-    renderConfigParity(content,cp);
-    renderEngineers(content,eng,prs);
-    box.append(content);
+    renderMetrics(box,health,parity);
+    renderHardware(box,health);
+    renderTrend(box,health);
+    renderHeatmap(box,parity);
+    renderGroups(box,parity);
+    renderFlaky(box,flaky);
+    renderOffenders(box,trends);
+    renderConfigParity(box,cp);
+    renderEngineers(box,eng,prs);
   }
 
   const obs=new MutationObserver(()=>{

--- a/docs/assets/js/ci-queue.js
+++ b/docs/assets/js/ci-queue.js
@@ -83,27 +83,10 @@
     let metric = 'waiting'; // or 'running'
     let chart = null;
 
-    // Title + project selector
-    container.append(h('h2',{text:'Queue Monitor',style:{marginBottom:'4px'}}));
+    // Title (project selector removed — handled by sidebar)
+    container.append(h('h2',{text:'Queue Monitor',style:{marginBottom:'16px'}}));
 
-    // Project selector bar
-    const allProjects = ['vllm','pytorch','jax','triton','sglang','xla'];
-    const projBar = h('div',{style:{display:'flex',gap:'4px',marginBottom:'16px',borderBottom:`1px solid ${C.bd}`,paddingBottom:'8px'}});
-    const contentWrap = h('div');
-    for (const p of allProjects) {
-      const active = p === 'vllm';
-      const btn = h('button',{text:p,style:{background:active?C.b:'transparent',border:'none',color:C.t,padding:'6px 16px',borderRadius:'6px 6px 0 0',cursor:'pointer',fontSize:'13px',fontWeight:active?'700':'400',fontFamily:'inherit',borderBottom:active?`2px solid ${C.b}`:'2px solid transparent'}});
-      btn.onclick = () => {
-        projBar.querySelectorAll('button').forEach(b=>{b.style.background='transparent';b.style.borderBottomColor='transparent';b.style.fontWeight='400'});
-        btn.style.background=C.b;btn.style.borderBottomColor=C.b;btn.style.fontWeight='700';
-        if(p!=='vllm'){contentWrap.innerHTML='<div style="text-align:center;padding:60px;color:#8b949e"><h3>'+p+'</h3><p>Queue monitoring not yet configured.</p></div>';}
-        else{contentWrap.innerHTML='';renderQueueContent(contentWrap,snapshots);}
-      };
-      projBar.append(btn);
-    }
-    container.append(projBar);
-    container.append(contentWrap);
-    renderQueueContent(contentWrap, snapshots);
+    renderQueueContent(container, snapshots);
   }
 
   function renderQueueContent(container, snapshots) {

--- a/docs/assets/js/dashboard.js
+++ b/docs/assets/js/dashboard.js
@@ -239,16 +239,51 @@ function renderParityView(projectsCfg, dataMap, parityHistData) {
 
       html += '</div>';
 
-      // Pass rate bars - stacked vertically
+      // Pass rate bars - stacked by hardware
       if (d.ciHealth) {
         html += '<div style="margin-bottom:12px">';
+        // AMD bar segmented by hardware
         if (d.ciHealth.amd && d.ciHealth.amd.latest_build) {
           var lb = d.ciHealth.amd.latest_build;
-          html += buildPassRateBar("AMD (" + lb.total_tests.toLocaleString() + " tests)", { passed: lb.passed, failed: lb.failed, skipped: lb.skipped, pass_rate: parseFloat((lb.pass_rate * 100).toFixed(1)) });
+          var bh = lb.by_hardware || {};
+          var hwColors = {mi250:'#ff6b6b',mi325:'#da3633',mi355:'#b71c1c'};
+          var hwNames = {mi250:'MI250',mi325:'MI325',mi355:'MI355'};
+          html += '<div class="pass-rate-row">';
+          html += '<span class="pass-rate-label" style="cursor:pointer" onclick="document.querySelector(\'.nav-btn[data-tab=ci-health]\').click()">AMD (' + lb.total_tests.toLocaleString() + ' tests)</span>';
+          html += '<div class="pass-rate-bar-bg">';
+          // Stacked segments per hardware
+          var totalTests = lb.total_tests || 1;
+          var hwEntries = Object.entries(bh).filter(function(e){return e[0]!=="unknown"}).sort();
+          if (hwEntries.length > 0) {
+            for (var hi = 0; hi < hwEntries.length; hi++) {
+              var hwKey = hwEntries[hi][0], hwData = hwEntries[hi][1];
+              var segPct = ((hwData.passed || 0) / totalTests * 100);
+              html += '<div style="width:' + segPct + '%;height:100%;background:' + (hwColors[hwKey]||'#da3633') + ';display:inline-block;position:relative" title="' + (hwNames[hwKey]||hwKey) + ': ' + (hwData.passed||0).toLocaleString() + ' passed / ' + (hwData.failed||0) + ' failed"></div>';
+            }
+          } else {
+            html += '<div class="pass-rate-bar-fill rate-good" style="width:' + (lb.pass_rate*100) + '%"></div>';
+          }
+          html += '</div>';
+          html += '<span class="pass-rate-pct">' + (lb.pass_rate * 100).toFixed(1) + '%</span>';
+          html += '</div>';
+          // Legend
+          if (hwEntries.length > 0) {
+            html += '<div style="display:flex;gap:12px;margin:4px 0 8px 160px;font-size:12px">';
+            for (var hi = 0; hi < hwEntries.length; hi++) {
+              var hwKey = hwEntries[hi][0], hwData = hwEntries[hi][1];
+              html += '<span><span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:' + (hwColors[hwKey]||'#da3633') + ';margin-right:4px"></span>' + (hwNames[hwKey]||hwKey) + ' (' + (hwData.pass_rate*100).toFixed(1) + '%)</span>';
+            }
+            html += '</div>';
+          }
         }
+        // Upstream bar (single color - blue)
         if (d.ciHealth.upstream && d.ciHealth.upstream.latest_build) {
           var ulb = d.ciHealth.upstream.latest_build;
-          html += buildPassRateBar("Upstream (" + ulb.total_tests.toLocaleString() + " tests)", { passed: ulb.passed, failed: ulb.failed, skipped: ulb.skipped, pass_rate: parseFloat((ulb.pass_rate * 100).toFixed(1)) });
+          html += '<div class="pass-rate-row">';
+          html += '<span class="pass-rate-label" style="cursor:pointer" onclick="document.querySelector(\'.nav-btn[data-tab=ci-health]\').click()">Upstream (' + ulb.total_tests.toLocaleString() + ' tests)</span>';
+          html += '<div class="pass-rate-bar-bg"><div style="width:' + (ulb.pass_rate*100) + '%;height:100%;background:#1f6feb;border-radius:4px"></div></div>';
+          html += '<span class="pass-rate-pct">' + (ulb.pass_rate * 100).toFixed(1) + '%</span>';
+          html += '</div>';
         }
         html += '</div>';
       }

--- a/docs/assets/js/dashboard.js
+++ b/docs/assets/js/dashboard.js
@@ -84,19 +84,19 @@
     document.getElementById("builds-view").innerHTML = '<p class="empty">Error rendering builds: ' + e.message + '</p>';
   }
 
-  // Tab switching
+  // Tab switching — works with sidebar .nav-btn elements
   function switchTab(target) {
-    document.querySelectorAll(".tab-btn").forEach(function (b) { b.classList.remove("active"); });
+    document.querySelectorAll(".nav-btn").forEach(function (b) { b.classList.remove("active"); });
     document.querySelectorAll(".tab-panel").forEach(function (p) { p.classList.remove("active"); });
-    var btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
+    var btn = document.querySelector('.nav-btn[data-tab="' + target + '"]');
     if (btn) btn.classList.add("active");
     var panel = document.getElementById("tab-" + target);
     if (panel) panel.classList.add("active");
   }
 
-  var tabBtns = document.querySelectorAll(".tab-btn");
-  for (var i = 0; i < tabBtns.length; i++) {
-    tabBtns[i].addEventListener("click", function () {
+  var navBtns = document.querySelectorAll(".nav-btn");
+  for (var i = 0; i < navBtns.length; i++) {
+    navBtns[i].addEventListener("click", function () {
       var target = this.getAttribute("data-tab");
       switchTab(target);
       history.replaceState(null, "", "#" + target);
@@ -193,7 +193,7 @@ function renderParityView(projectsCfg, dataMap, parityHistData) {
     // vLLM CI parity card (from Buildkite CI data)
     if (name === "vllm" && d.ciParity) {
       var p = d.ciParity;
-      var groups = p.job_groups || [];
+      var groups = mergeShardedGroups(p.job_groups || []);
       var both = groups.filter(function(g) { return g.amd && g.upstream; });
       var amdOnly = groups.filter(function(g) { return g.amd && !g.upstream; });
       var upOnly = groups.filter(function(g) { return !g.amd && g.upstream; });
@@ -204,31 +204,15 @@ function renderParityView(projectsCfg, dataMap, parityHistData) {
       var bothFail = both.filter(function(g) { return (g.amd.failed || 0) > 0 && (g.upstream.failed || 0) > 0; });
       var total = both.length + amdOnly.length + upOnly.length;
 
-      // Get test counts from CI health data
-      var amdTests = '', upTests = '', amdTG = '', upTG = '';
-      if (d.ciHealth) {
-        var amdBuild = d.ciHealth.amd && d.ciHealth.amd.latest_build;
-        var upBuild = d.ciHealth.upstream && d.ciHealth.upstream.latest_build;
-        if (amdBuild) {
-          amdTests = amdBuild.total_tests.toLocaleString() + ' unit tests';
-          amdTG = amdBuild.test_groups + ' test groups';
-        }
-        if (upBuild) {
-          upTests = upBuild.total_tests.toLocaleString() + ' unit tests';
-          upTG = upBuild.test_groups + ' test groups';
-        }
-      }
-
       html += '<div class="parity-card" style="max-width:none">';
-      html += '<div class="parity-card-header"><h3>' + (cfg.display_name || 'vLLM') + ' — AMD vs Upstream CI Parity</h3></div>';
+      html += '<div class="parity-card-header"><h3><a href="https://github.com/' + cfg.repo + '" target="_blank">vLLM</a></h3></div>';
 
       // 5-column stats: AMD total | Common | Upstream total | AMD-only | Upstream-only
       html += '<div style="display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin:16px 0">';
 
       html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid var(--border);border-top:3px solid #da3633">';
       html += '<div style="font-size:24px;font-weight:800;color:#da3633">' + (both.length + amdOnly.length) + '</div>';
-      html += '<div style="font-size:13px;color:var(--text-muted)">AMD Test Groups</div>';
-      html += '<div style="font-size:12px;color:var(--text-muted);margin-top:4px">' + amdTests + '</div></div>';
+      html += '<div style="font-size:13px;color:var(--text-muted)">AMD Test Groups</div></div>';
 
       html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid var(--border);border-top:3px solid #238636">';
       html += '<div style="font-size:24px;font-weight:800;color:#238636">' + both.length + '</div>';
@@ -237,8 +221,7 @@ function renderParityView(projectsCfg, dataMap, parityHistData) {
 
       html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid var(--border);border-top:3px solid #1f6feb">';
       html += '<div style="font-size:24px;font-weight:800;color:#1f6feb">' + (both.length + upOnly.length) + '</div>';
-      html += '<div style="font-size:13px;color:var(--text-muted)">Upstream Test Groups</div>';
-      html += '<div style="font-size:12px;color:var(--text-muted);margin-top:4px">' + upTests + '</div></div>';
+      html += '<div style="font-size:13px;color:var(--text-muted)">Upstream Test Groups</div></div>';
 
       html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid rgba(218,54,51,0.2);border-top:3px solid #da3633">';
       html += '<div style="font-size:24px;font-weight:800;color:#da3633">' + amdOnly.length + '</div>';
@@ -250,16 +233,16 @@ function renderParityView(projectsCfg, dataMap, parityHistData) {
 
       html += '</div>';
 
-      // Pass rate bars - AMD and Upstream side by side
+      // Pass rate bars - stacked vertically
       if (d.ciHealth) {
-        html += '<div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:12px">';
+        html += '<div style="margin-bottom:12px">';
         if (d.ciHealth.amd && d.ciHealth.amd.latest_build) {
           var lb = d.ciHealth.amd.latest_build;
-          html += '<div>' + buildPassRateBar("AMD Pass Rate (" + lb.total_tests.toLocaleString() + " tests)", { passed: lb.passed, failed: lb.failed, skipped: lb.skipped, pass_rate: parseFloat((lb.pass_rate * 100).toFixed(1)) }) + '</div>';
+          html += buildPassRateBar("AMD (" + lb.total_tests.toLocaleString() + " tests)", { passed: lb.passed, failed: lb.failed, skipped: lb.skipped, pass_rate: parseFloat((lb.pass_rate * 100).toFixed(1)) });
         }
         if (d.ciHealth.upstream && d.ciHealth.upstream.latest_build) {
           var ulb = d.ciHealth.upstream.latest_build;
-          html += '<div>' + buildPassRateBar("Upstream Pass Rate (" + ulb.total_tests.toLocaleString() + " tests)", { passed: ulb.passed, failed: ulb.failed, skipped: ulb.skipped, pass_rate: parseFloat((ulb.pass_rate * 100).toFixed(1)) }) + '</div>';
+          html += buildPassRateBar("Upstream (" + ulb.total_tests.toLocaleString() + " tests)", { passed: ulb.passed, failed: ulb.failed, skipped: ulb.skipped, pass_rate: parseFloat((ulb.pass_rate * 100).toFixed(1)) });
         }
         html += '</div>';
       }

--- a/docs/assets/js/dashboard.js
+++ b/docs/assets/js/dashboard.js
@@ -204,30 +204,36 @@ function renderParityView(projectsCfg, dataMap, parityHistData) {
       var bothFail = both.filter(function(g) { return (g.amd.failed || 0) > 0 && (g.upstream.failed || 0) > 0; });
       var total = both.length + amdOnly.length + upOnly.length;
 
+      // Store groups on window for overlay access
+      var overlayId = 'parity_' + Date.now();
+      window['_parityData_' + overlayId] = { both: both, amdOnly: amdOnly, upOnly: upOnly, groups: groups };
+
       html += '<div class="parity-card" style="max-width:none">';
       html += '<div class="parity-card-header"><h3><a href="https://github.com/' + cfg.repo + '" target="_blank">vLLM</a></h3></div>';
 
-      // 5-column stats: AMD total | Common | Upstream total | AMD-only | Upstream-only
+      // 5-column stats — each clickable to show group list overlay
       html += '<div style="display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin:16px 0">';
 
-      html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid var(--border);border-top:3px solid #da3633">';
+      html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid var(--border);border-top:3px solid #da3633;cursor:pointer;transition:transform .15s,box-shadow .15s" onclick="showGroupOverlay(\'' + overlayId + '\',\'amd\')" onmouseenter="this.style.transform=\'translateY(-2px)\';this.style.boxShadow=\'0 4px 12px rgba(0,0,0,.3)\'" onmouseleave="this.style.transform=\'\';this.style.boxShadow=\'\'">';
       html += '<div style="font-size:24px;font-weight:800;color:#da3633">' + (both.length + amdOnly.length) + '</div>';
-      html += '<div style="font-size:13px;color:var(--text-muted)">AMD Test Groups</div></div>';
+      html += '<div style="font-size:13px;color:var(--text-muted)">AMD Test Groups</div>';
+      html += '<div style="font-size:11px;color:var(--text-muted);margin-top:4px">click to view</div></div>';
 
-      html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid var(--border);border-top:3px solid #238636">';
+      html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid var(--border);border-top:3px solid #238636;cursor:pointer;transition:transform .15s,box-shadow .15s" onclick="showGroupOverlay(\'' + overlayId + '\',\'common\')" onmouseenter="this.style.transform=\'translateY(-2px)\';this.style.boxShadow=\'0 4px 12px rgba(0,0,0,.3)\'" onmouseleave="this.style.transform=\'\';this.style.boxShadow=\'\'">';
       html += '<div style="font-size:24px;font-weight:800;color:#238636">' + both.length + '</div>';
       html += '<div style="font-size:13px;color:var(--text-muted)">Common Groups</div>';
       html += '<div style="font-size:12px;color:var(--text-muted);margin-top:4px">' + Math.round(both.length / total * 100) + '% overlap</div></div>';
 
-      html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid var(--border);border-top:3px solid #1f6feb">';
+      html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid var(--border);border-top:3px solid #1f6feb;cursor:pointer;transition:transform .15s,box-shadow .15s" onclick="showGroupOverlay(\'' + overlayId + '\',\'upstream\')" onmouseenter="this.style.transform=\'translateY(-2px)\';this.style.boxShadow=\'0 4px 12px rgba(0,0,0,.3)\'" onmouseleave="this.style.transform=\'\';this.style.boxShadow=\'\'">';
       html += '<div style="font-size:24px;font-weight:800;color:#1f6feb">' + (both.length + upOnly.length) + '</div>';
-      html += '<div style="font-size:13px;color:var(--text-muted)">Upstream Test Groups</div></div>';
+      html += '<div style="font-size:13px;color:var(--text-muted)">Upstream Test Groups</div>';
+      html += '<div style="font-size:11px;color:var(--text-muted);margin-top:4px">click to view</div></div>';
 
-      html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid rgba(218,54,51,0.2);border-top:3px solid #da3633">';
+      html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid rgba(218,54,51,0.2);border-top:3px solid #da3633;cursor:pointer;transition:transform .15s,box-shadow .15s" onclick="showGroupOverlay(\'' + overlayId + '\',\'amd-only\')" onmouseenter="this.style.transform=\'translateY(-2px)\';this.style.boxShadow=\'0 4px 12px rgba(0,0,0,.3)\'" onmouseleave="this.style.transform=\'\';this.style.boxShadow=\'\'">';
       html += '<div style="font-size:24px;font-weight:800;color:#da3633">' + amdOnly.length + '</div>';
       html += '<div style="font-size:13px;color:var(--text-muted)">AMD-Only</div></div>';
 
-      html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid rgba(31,111,235,0.2);border-top:3px solid #1f6feb">';
+      html += '<div style="text-align:center;padding:14px;background:var(--bg);border-radius:6px;border:1px solid rgba(31,111,235,0.2);border-top:3px solid #1f6feb;cursor:pointer;transition:transform .15s,box-shadow .15s" onclick="showGroupOverlay(\'' + overlayId + '\',\'upstream-only\')" onmouseenter="this.style.transform=\'translateY(-2px)\';this.style.boxShadow=\'0 4px 12px rgba(0,0,0,.3)\'" onmouseleave="this.style.transform=\'\';this.style.boxShadow=\'\'">';
       html += '<div style="font-size:24px;font-weight:800;color:#1f6feb">' + upOnly.length + '</div>';
       html += '<div style="font-size:13px;color:var(--text-muted)">Upstream-Only</div></div>';
 

--- a/docs/assets/js/utils.js
+++ b/docs/assets/js/utils.js
@@ -157,15 +157,23 @@ function effectiveAuthor(pr) {
 }
 
 /**
- * Merge sharded test groups (e.g., "lora 1", "lora 2" -> "lora")
- * Shards are identified by a trailing numeric suffix separated by space.
+ * Merge sharded test groups into their base group.
+ * Patterns merged:
+ *   "lora 1", "lora 2" -> "lora"
+ *   "multi-modal models (standard) 1: qwen2" -> "multi-modal models (standard)"
+ *   "multi-modal models (extended generation 1)" -> "multi-modal models (extended generation)"
  */
 function mergeShardedGroups(groups) {
   var baseMap = {};
   for (var i = 0; i < groups.length; i++) {
     var g = groups[i];
     var name = g.name || '';
+    // Strip trailing " N" (simple shard)
     var baseName = name.replace(/\s+\d+$/, '');
+    // Strip " N: description" (labeled shard like "1: qwen2")
+    baseName = baseName.replace(/\s+\d+\s*:.*$/, '');
+    // Strip trailing " N)" -> ")" (digit before closing paren like "extended generation 1)")
+    baseName = baseName.replace(/\s+\d+\)$/, ')');
     if (!baseMap[baseName]) {
       baseMap[baseName] = { name: baseName, amd: null, upstream: null, hardware: [], hw_failures: {}, job_links: [], failure_tests: [] };
     }
@@ -193,6 +201,102 @@ function mergeShardedGroups(groups) {
     baseMap[key].hardware = baseMap[key].hardware.filter(function(v, i, a) { return a.indexOf(v) === i; });
   }
   return Object.values(baseMap);
+}
+
+/**
+ * Show an overlay popup listing test groups for a given category.
+ */
+function showGroupOverlay(dataId, category) {
+  var data = window['_parityData_' + dataId];
+  if (!data) return;
+
+  var title = '', groupList = [], color = '';
+  if (category === 'amd') {
+    title = 'AMD Test Groups';
+    color = '#da3633';
+    groupList = data.groups.filter(function(g) { return g.amd; });
+  } else if (category === 'common') {
+    title = 'Common Groups (AMD + Upstream)';
+    color = '#238636';
+    groupList = data.both;
+  } else if (category === 'upstream') {
+    title = 'Upstream Test Groups';
+    color = '#1f6feb';
+    groupList = data.groups.filter(function(g) { return g.upstream; });
+  } else if (category === 'amd-only') {
+    title = 'AMD-Only Test Groups';
+    color = '#da3633';
+    groupList = data.amdOnly;
+  } else if (category === 'upstream-only') {
+    title = 'Upstream-Only Test Groups';
+    color = '#1f6feb';
+    groupList = data.upOnly;
+  }
+
+  groupList = groupList.sort(function(a, b) { return (a.name || '').localeCompare(b.name || ''); });
+
+  // Build overlay DOM
+  var backdrop = document.createElement('div');
+  backdrop.className = 'overlay-backdrop';
+  backdrop.onclick = function(e) { if (e.target === backdrop) backdrop.remove(); };
+
+  var panel = document.createElement('div');
+  panel.className = 'overlay-panel';
+
+  var header = document.createElement('div');
+  header.className = 'overlay-header';
+  header.innerHTML = '<h3 style="color:' + color + '">' + escapeHtml(title) + ' <span style="color:var(--text-muted);font-weight:400">(' + groupList.length + ')</span></h3>';
+
+  var closeBtn = document.createElement('button');
+  closeBtn.className = 'overlay-close';
+  closeBtn.innerHTML = '&times;';
+  closeBtn.onclick = function() { backdrop.remove(); };
+  header.appendChild(closeBtn);
+
+  var body = document.createElement('div');
+  body.className = 'overlay-body';
+
+  // Build table
+  var tbl = '<table style="width:100%;border-collapse:collapse;font-size:13px">';
+  tbl += '<thead><tr>';
+  tbl += '<th style="text-align:left;padding:6px 10px;border-bottom:2px solid var(--border);color:var(--text-muted);font-size:11px;font-weight:600">Test Group</th>';
+  if (category === 'common' || category === 'amd' || category === 'upstream') {
+    tbl += '<th style="text-align:center;padding:6px 10px;border-bottom:2px solid var(--border);color:var(--text-muted);font-size:11px;font-weight:600">AMD P/F</th>';
+    tbl += '<th style="text-align:center;padding:6px 10px;border-bottom:2px solid var(--border);color:var(--text-muted);font-size:11px;font-weight:600">Upstream P/F</th>';
+  }
+  tbl += '</tr></thead><tbody>';
+
+  for (var i = 0; i < groupList.length; i++) {
+    var g = groupList[i];
+    tbl += '<tr style="border-bottom:1px solid var(--border)">';
+    tbl += '<td style="padding:5px 10px">' + escapeHtml(g.name) + '</td>';
+    if (category === 'common' || category === 'amd' || category === 'upstream') {
+      if (g.amd) {
+        var af = g.amd.failed || 0;
+        tbl += '<td style="text-align:center;padding:5px 10px"><span style="color:#238636">' + (g.amd.passed||0) + '</span>/<span style="color:' + (af > 0 ? '#da3633' : 'var(--text-muted)') + '">' + af + '</span></td>';
+      } else {
+        tbl += '<td style="text-align:center;padding:5px 10px;color:var(--text-muted)">-</td>';
+      }
+      if (g.upstream) {
+        var uf = g.upstream.failed || 0;
+        tbl += '<td style="text-align:center;padding:5px 10px"><span style="color:#238636">' + (g.upstream.passed||0) + '</span>/<span style="color:' + (uf > 0 ? '#da3633' : 'var(--text-muted)') + '">' + uf + '</span></td>';
+      } else {
+        tbl += '<td style="text-align:center;padding:5px 10px;color:var(--text-muted)">-</td>';
+      }
+    }
+    tbl += '</tr>';
+  }
+  tbl += '</tbody></table>';
+  body.innerHTML = tbl;
+
+  panel.appendChild(header);
+  panel.appendChild(body);
+  backdrop.appendChild(panel);
+  document.body.appendChild(backdrop);
+
+  // Close on Escape
+  var escHandler = function(e) { if (e.key === 'Escape') { backdrop.remove(); document.removeEventListener('keydown', escHandler); } };
+  document.addEventListener('keydown', escHandler);
 }
 
 function getProjectContributors(prs, limit) {

--- a/docs/assets/js/utils.js
+++ b/docs/assets/js/utils.js
@@ -156,6 +156,45 @@ function effectiveAuthor(pr) {
   return pr.original_author || pr.author;
 }
 
+/**
+ * Merge sharded test groups (e.g., "lora 1", "lora 2" -> "lora")
+ * Shards are identified by a trailing numeric suffix separated by space.
+ */
+function mergeShardedGroups(groups) {
+  var baseMap = {};
+  for (var i = 0; i < groups.length; i++) {
+    var g = groups[i];
+    var name = g.name || '';
+    var baseName = name.replace(/\s+\d+$/, '');
+    if (!baseMap[baseName]) {
+      baseMap[baseName] = { name: baseName, amd: null, upstream: null, hardware: [], hw_failures: {}, job_links: [], failure_tests: [] };
+    }
+    var base = baseMap[baseName];
+    if (g.amd) {
+      if (!base.amd) base.amd = { passed: 0, failed: 0, skipped: 0, total: 0 };
+      base.amd.passed += (g.amd.passed || 0);
+      base.amd.failed += (g.amd.failed || 0);
+      base.amd.skipped += (g.amd.skipped || 0);
+      base.amd.total += (g.amd.total || 0);
+    }
+    if (g.upstream) {
+      if (!base.upstream) base.upstream = { passed: 0, failed: 0, skipped: 0, total: 0 };
+      base.upstream.passed += (g.upstream.passed || 0);
+      base.upstream.failed += (g.upstream.failed || 0);
+      base.upstream.skipped += (g.upstream.skipped || 0);
+      base.upstream.total += (g.upstream.total || 0);
+    }
+    if (g.hardware) base.hardware = base.hardware.concat(g.hardware);
+    if (g.hw_failures) { for (var hw in g.hw_failures) base.hw_failures[hw] = (base.hw_failures[hw] || 0) + g.hw_failures[hw]; }
+    if (g.job_links) base.job_links = base.job_links.concat(g.job_links);
+    if (g.failure_tests) base.failure_tests = base.failure_tests.concat(g.failure_tests);
+  }
+  for (var key in baseMap) {
+    baseMap[key].hardware = baseMap[key].hardware.filter(function(v, i, a) { return a.indexOf(v) === i; });
+  }
+  return Object.values(baseMap);
+}
+
 function getProjectContributors(prs, limit) {
   const map = new Map();
   for (const pr of prs) {

--- a/docs/assets/js/utils.js
+++ b/docs/assets/js/utils.js
@@ -257,31 +257,38 @@ function showGroupOverlay(dataId, category) {
   body.className = 'overlay-body';
 
   // Build table
-  var tbl = '<table style="width:100%;border-collapse:collapse;font-size:13px">';
+  var showBoth = (category === 'common' || category === 'amd' || category === 'upstream');
+  var tbl = '<table style="width:100%;border-collapse:collapse;font-size:14px">';
   tbl += '<thead><tr>';
-  tbl += '<th style="text-align:left;padding:6px 10px;border-bottom:2px solid var(--border);color:var(--text-muted);font-size:11px;font-weight:600">Test Group</th>';
-  if (category === 'common' || category === 'amd' || category === 'upstream') {
-    tbl += '<th style="text-align:center;padding:6px 10px;border-bottom:2px solid var(--border);color:var(--text-muted);font-size:11px;font-weight:600">AMD P/F</th>';
-    tbl += '<th style="text-align:center;padding:6px 10px;border-bottom:2px solid var(--border);color:var(--text-muted);font-size:11px;font-weight:600">Upstream P/F</th>';
+  tbl += '<th style="text-align:left;padding:8px 12px;border-bottom:2px solid var(--border);color:var(--text-muted);font-size:12px;font-weight:600">Test Group</th>';
+  if (showBoth) {
+    tbl += '<th style="text-align:center;padding:8px 12px;border-bottom:2px solid var(--border);color:#da3633;font-size:12px;font-weight:600">AMD P/F</th>';
+    tbl += '<th style="text-align:center;padding:8px 12px;border-bottom:2px solid var(--border);color:#1f6feb;font-size:12px;font-weight:600">Upstream P/F</th>';
   }
   tbl += '</tr></thead><tbody>';
 
   for (var i = 0; i < groupList.length; i++) {
     var g = groupList[i];
-    tbl += '<tr style="border-bottom:1px solid var(--border)">';
-    tbl += '<td style="padding:5px 10px">' + escapeHtml(g.name) + '</td>';
-    if (category === 'common' || category === 'amd' || category === 'upstream') {
-      if (g.amd) {
+    var hasAmd = !!g.amd;
+    var hasUp = !!g.upstream;
+    // Color-code: red bg if missing on one side, green text if present
+    var rowBg = '';
+    if (showBoth && !hasAmd) rowBg = 'background:rgba(218,54,51,0.08);';
+    if (showBoth && !hasUp) rowBg = 'background:rgba(31,111,235,0.08);';
+    tbl += '<tr style="border-bottom:1px solid var(--border);' + rowBg + '">';
+    tbl += '<td style="padding:6px 12px">' + escapeHtml(g.name) + '</td>';
+    if (showBoth) {
+      if (hasAmd) {
         var af = g.amd.failed || 0;
-        tbl += '<td style="text-align:center;padding:5px 10px"><span style="color:#238636">' + (g.amd.passed||0) + '</span>/<span style="color:' + (af > 0 ? '#da3633' : 'var(--text-muted)') + '">' + af + '</span></td>';
+        tbl += '<td style="text-align:center;padding:6px 12px"><span style="color:#238636;font-weight:600">' + (g.amd.passed||0) + '</span>/<span style="color:' + (af > 0 ? '#da3633' : 'var(--text-muted)') + ';font-weight:600">' + af + '</span></td>';
       } else {
-        tbl += '<td style="text-align:center;padding:5px 10px;color:var(--text-muted)">-</td>';
+        tbl += '<td style="text-align:center;padding:6px 12px"><span style="color:#da3633;font-weight:600;font-size:13px">not in AMD CI</span></td>';
       }
-      if (g.upstream) {
+      if (hasUp) {
         var uf = g.upstream.failed || 0;
-        tbl += '<td style="text-align:center;padding:5px 10px"><span style="color:#238636">' + (g.upstream.passed||0) + '</span>/<span style="color:' + (uf > 0 ? '#da3633' : 'var(--text-muted)') + '">' + uf + '</span></td>';
+        tbl += '<td style="text-align:center;padding:6px 12px"><span style="color:#238636;font-weight:600">' + (g.upstream.passed||0) + '</span>/<span style="color:' + (uf > 0 ? '#da3633' : 'var(--text-muted)') + ';font-weight:600">' + uf + '</span></td>';
       } else {
-        tbl += '<td style="text-align:center;padding:5px 10px;color:var(--text-muted)">-</td>';
+        tbl += '<td style="text-align:center;padding:6px 12px"><span style="color:#1f6feb;font-weight:600;font-size:13px">not in Upstream</span></td>';
       }
     }
     tbl += '</tr>';

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,62 +4,98 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Project Dashboard</title>
-  <link rel="stylesheet" href="assets/css/dashboard.css?v=6">
+  <link rel="stylesheet" href="assets/css/dashboard.css?v=7">
 </head>
 <body>
-  <header>
-    <h1>Project Dashboard</h1>
-    <p id="last-updated">Loading...</p>
-  </header>
+  <!-- Sidebar Navigation -->
+  <aside id="sidebar">
+    <div class="sidebar-header">
+      <h1>Project Dashboard</h1>
+      <p id="last-updated">Loading...</p>
+    </div>
+    <nav id="sidebar-nav">
+      <button class="nav-btn active" data-tab="projects">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9z"/></svg>
+        Projects
+      </button>
+      <button class="nav-btn" data-tab="test-parity">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0a8 8 0 110 16A8 8 0 018 0zM1.5 8a6.5 6.5 0 1013 0 6.5 6.5 0 00-13 0zm9.78-2.22l-5.5 5.5a.75.75 0 01-1.06-1.06l5.5-5.5a.75.75 0 011.06 1.06z"/></svg>
+        Test Parity
+      </button>
+      <button class="nav-btn" data-tab="activity">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 1.75a.75.75 0 00-1.5 0v12.5c0 .414.336.75.75.75h14.5a.75.75 0 000-1.5H1.5V1.75zm14.28 2.53a.75.75 0 00-1.06-1.06L10 7.94 7.53 5.47a.75.75 0 00-1.06 0L3.22 8.72a.75.75 0 001.06 1.06L7 7.06l2.47 2.47a.75.75 0 001.06 0l5.25-5.25z"/></svg>
+        Activity
+      </button>
+      <button class="nav-btn" data-tab="trends">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 1.75a.75.75 0 00-1.5 0v12.5c0 .414.336.75.75.75h14.5a.75.75 0 000-1.5H1.5V1.75zm14.28 2.53a.75.75 0 00-1.06-1.06L10 7.94 7.53 5.47a.75.75 0 00-1.06 0L3.22 8.72a.75.75 0 001.06 1.06L7 7.06l2.47 2.47a.75.75 0 001.06 0l5.25-5.25z"/></svg>
+        Trends
+      </button>
+      <button class="nav-btn" data-tab="builds">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0114.25 16H1.75A1.75 1.75 0 010 14.25V1.75zM1.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h12.5a.25.25 0 00.25-.25V1.75a.25.25 0 00-.25-.25H1.75z"/></svg>
+        Builds
+      </button>
 
-  <nav id="tab-bar">
-    <button class="tab-btn active" data-tab="projects">Projects</button>
-    <button class="tab-btn" data-tab="test-parity">Test Parity</button>
-    <button class="tab-btn" data-tab="activity">Activity</button>
-    <button class="tab-btn" data-tab="trends">Trends</button>
-    <button class="tab-btn" data-tab="builds">Builds</button>
-    <button class="tab-btn" data-tab="ci-health">CI Health</button>
-    <button class="tab-btn" data-tab="ci-analytics">CI Analytics</button>
-    <button class="tab-btn" data-tab="ci-queue">Queue Monitor</button>
-    <button class="tab-btn" data-tab="op-coverage">AI Operator Coverage</button>
-  </nav>
+      <div class="nav-section-label">vLLM CI</div>
+      <button class="nav-btn" data-tab="ci-health">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>
+        CI Health
+      </button>
+      <button class="nav-btn" data-tab="ci-analytics">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 1.75a.75.75 0 00-1.5 0v12.5c0 .414.336.75.75.75h14.5a.75.75 0 000-1.5H1.5V1.75zM3.5 11a1 1 0 110-2 1 1 0 010 2zm4.75-2.5a1 1 0 100-2 1 1 0 000 2zM13 7.5a1 1 0 11-2 0 1 1 0 012 0zm-5.5-3a1 1 0 100-2 1 1 0 000 2z"/></svg>
+        CI Analytics
+      </button>
+      <button class="nav-btn" data-tab="ci-queue">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0a8 8 0 110 16A8 8 0 018 0zM1.5 8a6.5 6.5 0 1013 0 6.5 6.5 0 00-13 0zm7.25-3.25v2.992l2.028.812a.75.75 0 01-.556 1.392l-2.5-1A.75.75 0 017 8.25v-3.5a.75.75 0 011.5 0z"/></svg>
+        Queue Monitor
+      </button>
 
-  <div id="tab-projects" class="tab-panel active">
-    <section id="weekly-summary"></section>
-    <main id="dashboard"></main>
-  </div>
+      <div class="nav-section-label">Tools</div>
+      <button class="nav-btn" data-tab="op-coverage">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M6.122.392a1.75 1.75 0 013.756 0l.543 2.733.835.266A8.008 8.008 0 0114.3 5.84l.572.72 2.747-.46a1.75 1.75 0 011.878 2.676l-2.204 1.74.192.874a7.416 7.416 0 010 2.22l-.192.874 2.204 1.74a1.75 1.75 0 01-1.878 2.675l-2.747-.46-.572.72"/></svg>
+        AI Op Coverage
+      </button>
+    </nav>
+  </aside>
 
-  <div id="tab-test-parity" class="tab-panel">
-    <section id="parity-view"></section>
-  </div>
+  <!-- Main Content -->
+  <main id="main-content">
+    <div id="tab-projects" class="tab-panel active">
+      <section id="weekly-summary"></section>
+      <main id="dashboard"></main>
+    </div>
 
-  <div id="tab-activity" class="tab-panel">
-    <section id="activity-view"></section>
-  </div>
+    <div id="tab-test-parity" class="tab-panel">
+      <section id="parity-view"></section>
+    </div>
 
-  <div id="tab-trends" class="tab-panel">
-    <section id="trends-view"></section>
-  </div>
+    <div id="tab-activity" class="tab-panel">
+      <section id="activity-view"></section>
+    </div>
 
-  <div id="tab-builds" class="tab-panel">
-    <section id="builds-view"></section>
-  </div>
+    <div id="tab-trends" class="tab-panel">
+      <section id="trends-view"></section>
+    </div>
 
-  <div id="tab-ci-health" class="tab-panel">
-    <section id="ci-health-view"></section>
-  </div>
+    <div id="tab-builds" class="tab-panel">
+      <section id="builds-view"></section>
+    </div>
 
-  <div id="tab-ci-analytics" class="tab-panel">
-    <section id="ci-analytics-view"></section>
-  </div>
+    <div id="tab-ci-health" class="tab-panel">
+      <section id="ci-health-view"></section>
+    </div>
 
-  <div id="tab-ci-queue" class="tab-panel">
-    <section id="ci-queue-view"></section>
-  </div>
+    <div id="tab-ci-analytics" class="tab-panel">
+      <section id="ci-analytics-view"></section>
+    </div>
 
-  <div id="tab-op-coverage" class="tab-panel">
-    <section id="op-coverage-view"></section>
-  </div>
+    <div id="tab-ci-queue" class="tab-panel">
+      <section id="ci-queue-view"></section>
+    </div>
+
+    <div id="tab-op-coverage" class="tab-panel">
+      <section id="op-coverage-view"></section>
+    </div>
+  </main>
 
   <footer>
     <p>Data collected via <a href="https://github.com/sunway513/project-dashboard">project-dashboard</a></p>
@@ -69,10 +105,10 @@
   <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@dagrejs/dagre@1/dist/dagre.min.js"></script>
   <script src="assets/js/utils.js?v=5"></script>
-  <script src="assets/js/ci-health.js?v=8"></script>
-  <script src="assets/js/ci-analytics.js?v=6"></script>
-  <script src="assets/js/ci-queue.js?v=5"></script>
+  <script src="assets/js/ci-health.js?v=9"></script>
+  <script src="assets/js/ci-analytics.js?v=7"></script>
+  <script src="assets/js/ci-queue.js?v=6"></script>
   <script src="assets/js/op-coverage.js?v=6"></script>
-  <script src="assets/js/dashboard.js?v=6"></script>
+  <script src="assets/js/dashboard.js?v=7"></script>
 </body>
 </html>

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -37,8 +37,11 @@ pip install requests pyyaml
 
 ### Environment
 
+The `BUILDKITE_TOKEN` environment variable must be set. This is managed via GitHub Actions secrets — see the repo Settings > Secrets page. Never commit tokens to the repository.
+
 ```bash
-export BUILDKITE_TOKEN="bkua_your_token_here"
+# For local development only — use a read-only token
+export BUILDKITE_TOKEN="$YOUR_TOKEN"
 ```
 
 ### Run
@@ -116,50 +119,19 @@ Quarantined tests are still collected and tracked, but excluded from failure cou
 
 ## GitHub Actions Integration
 
-### Daily Cron (safety net)
+Three workflows handle automated CI data collection:
 
-The workflow `.github/workflows/daily-update.yml` runs `collect_ci.py` daily at 8AM UTC as part of the main dashboard update.
+| Workflow | Schedule | Purpose |
+|----------|----------|---------|
+| `daily-update.yml` | Hourly (:45) | Full data collection + site deployment |
+| `ci-collect.yml` | Daily (1 PM UTC) + webhook | Dedicated CI data collection from Buildkite |
+| `queue-monitor.yml` | Hourly (:15) | Queue time-series snapshots |
 
-### Webhook-Triggered (recommended)
+All secrets are managed via GitHub Actions encrypted secrets (Settings > Secrets > Actions). The `BUILDKITE_TOKEN` is never exposed in logs — GitHub automatically masks secret values.
 
-For real-time updates without polling, use `.github/workflows/ci-collect.yml` which is triggered by Buildkite webhooks via `repository_dispatch`.
+### Webhook-Triggered Updates
 
-**Setup:**
-
-1. Add secrets to your fork (Settings > Secrets > Actions):
-   - `BUILDKITE_TOKEN` — API token with `read_builds` scope
-   - `GITHUB_TOKEN` — already available by default
-
-2. Configure Buildkite webhook notification:
-   - Go to Buildkite > Organization Settings > Notification Services
-   - Add a new Webhook notification
-   - URL: `https://api.github.com/repos/YOUR_USER/YOUR_REPO/dispatches`
-   - Headers: `Authorization: Bearer YOUR_GITHUB_PAT`, `Accept: application/vnd.github+json`
-   - Body:
-     ```json
-     {
-       "event_type": "buildkite_build_finished",
-       "client_payload": {
-         "pipeline": "${pipeline.slug}",
-         "build_number": ${build.number}
-       }
-     }
-     ```
-   - Events: `build.finished`
-   - Pipelines: `amd-ci`, `ci`
-
-   **Note:** For the webhook to work, you need a GitHub Personal Access Token (PAT)
-   with `repo` scope set in the Buildkite notification headers. The `GITHUB_TOKEN`
-   secret from Actions cannot be used for external webhook auth.
-
-3. Alternatively, use the standalone webhook server (`scripts/ci/webhook.py`) if
-   you have a server that can receive HTTP requests:
-   ```bash
-   export GITHUB_TOKEN="ghp_..."
-   export GITHUB_REPO="your-user/your-dashboard-repo"
-   export BUILDKITE_WEBHOOK_SECRET="your-secret"
-   python scripts/ci/webhook.py
-   ```
+For real-time updates, `ci-collect.yml` can be triggered by Buildkite webhooks via `repository_dispatch`. Configure a Buildkite notification service to POST to the GitHub dispatches API with event type `buildkite_build_finished`.
 
 ## Architecture
 
@@ -179,7 +151,7 @@ scripts/
 
 ## Troubleshooting
 
-**"BUILDKITE_TOKEN not set"**: Export your token: `export BUILDKITE_TOKEN="bkua_..."`
+**"BUILDKITE_TOKEN not set"**: Ensure the token is configured in GitHub Actions secrets or exported in your local environment.
 
 **No nightly builds found**: The script filters by build name pattern. Check that the pipeline has builds matching "AMD Full CI Run.*nightly" or "Full CI run.*daily".
 

--- a/scripts/ci/buildkite_client.py
+++ b/scripts/ci/buildkite_client.py
@@ -22,7 +22,7 @@ def _headers() -> dict:
     token = cfg.BK_TOKEN
     if not token:
         raise RuntimeError(
-            "BUILDKITE_TOKEN not set. Export it: export BUILDKITE_TOKEN='bkua_...'"
+            "BUILDKITE_TOKEN not set. Configure it via GitHub Actions secrets or export it locally."
         )
     return {"Authorization": f"Bearer {token}"}
 

--- a/scripts/vllm/README.md
+++ b/scripts/vllm/README.md
@@ -1,0 +1,33 @@
+# vLLM Dashboard Scripts
+
+Additional data collection scripts specific to the vLLM CI dashboard.
+
+## Scripts
+
+| Script | Purpose | Trigger |
+|--------|---------|---------|
+| `collect_queue_snapshot.py` | Captures Buildkite queue state (waiting/running jobs per queue) | Hourly via `queue-monitor.yml` |
+| `collect_analytics.py` | Builds failure rankings, duration rankings, queue wait stats | Part of `collect_ci.py` |
+| `collect_activity.py` | Engineer activity profiles and contribution scoring | Part of `daily-update.yml` |
+| `config_parity.py` | Compares AMD vs NVIDIA CI config (commands, test lists) | Part of `collect_ci.py` |
+| `pr_scoring.py` | Scores PRs by importance (area, size, impact) | Part of `daily-update.yml` |
+| `pipelines.py` | Pipeline definitions (slug, name patterns, build filters) | Imported by other scripts |
+
+## Environment
+
+All scripts read the `BUILDKITE_TOKEN` from environment variables. This is managed via GitHub Actions encrypted secrets — never hardcode tokens in source files.
+
+## Data Flow
+
+```
+Buildkite API
+    |
+    v
+collect_queue_snapshot.py --> data/vllm/ci/queue_timeseries.jsonl
+collect_analytics.py      --> data/vllm/ci/analytics.json
+collect_activity.py       --> data/vllm/engineer_activity.json
+config_parity.py          --> data/vllm/ci/config_parity.json
+pr_scoring.py             --> data/vllm/pr_scores.json
+```
+
+These JSON files are then copied to `docs/data/vllm/` and deployed to GitHub Pages.


### PR DESCRIPTION
## Summary

- **Sidebar navigation**: Replace horizontal tab bar with fixed left sidebar, grouping CI Health / Analytics / Queue under a "vLLM CI" section
- **Visual upgrades**: Fade/slide animations, hover effects on cards, staggered card entry, smooth transitions throughout
- **Fix parity title**: Show "vLLM" with repo link instead of verbose "vLLM — AMD vs Upstream CI Parity"
- **Fix test group counting**: Merge sharded groups (e.g., "lora 1" + "lora 2" + "lora 3" → "lora") via `mergeShardedGroups()` utility
- **Stack pass rate bars**: AMD and Upstream bars now stacked vertically for easier comparison
- **Consolidate Hardware Breakdown**: Replace 3 large duplicate cards with a single compact table
- **Simplify CI Analytics**: Comparison-first view (no solo pipeline options), queue comparison splits AMD-only vs Other agents (NVIDIA sorted to top)
- **Remove project selectors**: All per-view project selectors removed since sidebar handles navigation

## Test plan

- [ ] Verify sidebar navigation switches between all panels correctly
- [ ] Check parity card shows "vLLM" with clickable repo link
- [ ] Confirm test group counts are lower (shards merged)
- [ ] Verify pass rate bars stack vertically
- [ ] Check Hardware Breakdown is a single table row
- [ ] Verify CI Analytics defaults to comparison view
- [ ] Check Queue Comparison has AMD column + Other column with NVIDIA on top

Generated with [Claude Code](https://claude.com/claude-code)