### PR TITLE
Add CI test suite with automated PR feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,181 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml requests pytest
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short 2>&1 | tee test-output.txt
+
+      - name: Comment test results on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('test-output.txt', 'utf8');
+            const lines = output.split('\n');
+
+            // Extract summary line
+            const summary = lines.find(l => l.includes('passed') || l.includes('failed') || l.includes('error')) || 'No summary';
+            const passed = (summary.match(/(\d+) passed/) || [,'0'])[1];
+            const failed = (summary.match(/(\d+) failed/) || [,'0'])[1];
+            const skipped = (summary.match(/(\d+) skipped/) || [,'0'])[1];
+            const hasFailures = parseInt(failed) > 0;
+
+            const icon = hasFailures ? '❌' : '✅';
+            const status = hasFailures ? 'FAILED' : 'PASSED';
+
+            let body = `## ${icon} CI Tests ${status}\n\n`;
+            body += `| Passed | Failed | Skipped |\n|--------|--------|--------|\n`;
+            body += `| ${passed} | ${failed} | ${skipped} |\n\n`;
+
+            if (hasFailures) {
+              // Show failed test details
+              const failures = lines.filter(l => l.includes('FAILED'));
+              if (failures.length) {
+                body += `### Failed Tests\n\`\`\`\n${failures.join('\n')}\n\`\`\`\n`;
+              }
+            }
+
+            body += `\n<details><summary>Full output</summary>\n\n\`\`\`\n${output.slice(-3000)}\n\`\`\`\n</details>`;
+
+            const prNum = context.payload.pull_request.number;
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: prNum
+            });
+            const existing = comments.data.find(c => c.body?.includes('CI Tests'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: prNum, body
+              });
+            }
+
+  validate-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check JS brace balance
+        run: |
+          FAIL=0
+          for f in docs/assets/js/*.js; do
+            OPEN=$(grep -o '{' "$f" | wc -l)
+            CLOSE=$(grep -o '}' "$f" | wc -l)
+            if [ "$OPEN" -ne "$CLOSE" ]; then
+              echo "❌ $f: $OPEN { vs $CLOSE }"
+              FAIL=1
+            else
+              echo "✅ $f: balanced ($OPEN)"
+            fi
+          done
+          exit $FAIL
+
+      - name: Check required files exist
+        run: |
+          for f in docs/index.html docs/assets/css/dashboard.css \
+                   docs/assets/js/dashboard.js docs/assets/js/ci-health.js \
+                   docs/assets/js/ci-analytics.js docs/assets/js/ci-queue.js \
+                   docs/assets/js/utils.js; do
+            if [ ! -f "$f" ]; then
+              echo "❌ Missing: $f"
+              exit 1
+            fi
+            echo "✅ $f exists"
+          done
+
+      - name: Validate HTML structure
+        run: |
+          # Check that index.html has all required elements
+          for id in sidebar main-content ci-health-view ci-analytics-view ci-queue-view parity-view; do
+            if ! grep -q "id=\"$id\"" docs/index.html; then
+              echo "❌ Missing element: #$id"
+              exit 1
+            fi
+            echo "✅ #$id present"
+          done
+
+  validate-data:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate JSON files
+        run: |
+          FAIL=0
+          for f in $(find data/ docs/data/ -name '*.json' -size +0c 2>/dev/null | head -50); do
+            if ! python3 -m json.tool "$f" > /dev/null 2>&1; then
+              echo "❌ Invalid JSON: $f"
+              FAIL=1
+            fi
+          done
+          if [ $FAIL -eq 1 ]; then exit 1; fi
+          echo "✅ All JSON files valid"
+
+      - name: Check CI data schema
+        run: |
+          python3 -c "
+          import json, sys
+          errors = []
+
+          # Validate ci_health.json
+          try:
+              d = json.load(open('data/vllm/ci/ci_health.json'))
+              if 'amd' not in d:
+                  errors.append('ci_health.json: missing amd key')
+              elif 'latest_build' not in d['amd']:
+                  errors.append('ci_health.json: missing amd.latest_build')
+              else:
+                  lb = d['amd']['latest_build']
+                  for f in ['total_tests','passed','failed','pass_rate']:
+                      if f not in lb:
+                          errors.append(f'ci_health.json: missing amd.latest_build.{f}')
+          except FileNotFoundError:
+              print('⚠️  ci_health.json not found (skipping)')
+          except Exception as e:
+              errors.append(f'ci_health.json: {e}')
+
+          # Validate parity_report.json
+          try:
+              d = json.load(open('data/vllm/ci/parity_report.json'))
+              if 'job_groups' not in d:
+                  errors.append('parity_report.json: missing job_groups')
+              elif len(d['job_groups']) == 0:
+                  errors.append('parity_report.json: job_groups is empty')
+          except FileNotFoundError:
+              print('⚠️  parity_report.json not found (skipping)')
+          except Exception as e:
+              errors.append(f'parity_report.json: {e}')
+
+          if errors:
+              for e in errors:
+                  print(f'❌ {e}')
+              sys.exit(1)
+          else:
+              print('✅ CI data schema valid')
+          "

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -1,0 +1,177 @@
+"""
+Data integrity tests for the project dashboard.
+Validates that CI data files have correct structure and the
+vLLM CI view will render correctly.
+"""
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+DATA = ROOT / "data"
+DOCS = ROOT / "docs"
+
+
+class TestCIHealthData:
+    @pytest.fixture
+    def health(self):
+        path = DATA / "vllm" / "ci" / "ci_health.json"
+        if not path.exists():
+            pytest.skip("ci_health.json not collected yet")
+        return json.loads(path.read_text())
+
+    def test_has_required_top_keys(self, health):
+        for key in ["generated_at", "amd", "upstream"]:
+            assert key in health
+
+    def test_amd_has_latest_build(self, health):
+        assert "latest_build" in health.get("amd", {})
+
+    def test_latest_build_has_required_fields(self, health):
+        lb = health["amd"]["latest_build"]
+        for f in ["build_number", "total_tests", "passed", "failed", "skipped", "pass_rate", "test_groups"]:
+            assert f in lb, f"missing: {f}"
+
+    def test_pass_rate_is_valid(self, health):
+        assert 0 <= health["amd"]["latest_build"]["pass_rate"] <= 1
+
+    def test_test_counts_consistent(self, health):
+        lb = health["amd"]["latest_build"]
+        assert lb["passed"] + lb["failed"] + lb.get("errors", 0) <= lb["total_tests"]
+
+    def test_hardware_breakdown_exists(self, health):
+        assert len(health["amd"]["latest_build"].get("by_hardware", {})) > 0
+
+    def test_hardware_pass_rates_valid(self, health):
+        for hw, d in health["amd"]["latest_build"].get("by_hardware", {}).items():
+            if hw == "unknown": continue
+            assert 0 <= d["pass_rate"] <= 1, f"{hw} pass_rate={d['pass_rate']}"
+
+
+class TestParityReport:
+    @pytest.fixture
+    def parity(self):
+        path = DATA / "vllm" / "ci" / "parity_report.json"
+        if not path.exists():
+            pytest.skip("parity_report.json not collected yet")
+        return json.loads(path.read_text())
+
+    def test_has_job_groups(self, parity):
+        assert len(parity.get("job_groups", [])) > 0
+
+    def test_groups_have_names(self, parity):
+        for g in parity["job_groups"]:
+            assert g.get("name"), f"empty name: {g}"
+
+    def test_groups_have_side(self, parity):
+        for g in parity["job_groups"]:
+            assert g.get("amd") or g.get("upstream"), f"'{g['name']}' has no side"
+
+    def test_no_negative_counts(self, parity):
+        for g in parity["job_groups"]:
+            for side in ["amd", "upstream"]:
+                d = g.get(side)
+                if not d: continue
+                for f in ["passed", "failed", "skipped"]:
+                    assert d.get(f, 0) >= 0, f"'{g['name']}' {side}.{f} < 0"
+
+
+class TestAnalyticsData:
+    @pytest.fixture
+    def analytics(self):
+        path = DATA / "vllm" / "ci" / "analytics.json"
+        if not path.exists():
+            pytest.skip("analytics.json not collected yet")
+        return json.loads(path.read_text())
+
+    def test_has_pipelines(self, analytics):
+        assert len(analytics) > 0
+
+    def test_pipelines_have_summary(self, analytics):
+        for p, d in analytics.items():
+            assert "summary" in d, f"{p} missing summary"
+
+    def test_builds_have_jobs(self, analytics):
+        for p, d in analytics.items():
+            builds = d.get("builds", [])
+            if builds:
+                assert "jobs" in builds[0], f"{p} build missing jobs"
+
+
+class TestFrontendFiles:
+    def test_index_html_exists(self):
+        assert (DOCS / "index.html").exists()
+
+    def test_index_html_has_sidebar(self):
+        html = (DOCS / "index.html").read_text()
+        assert 'id="sidebar"' in html
+        assert 'id="main-content"' in html
+
+    def test_all_tabs_present(self):
+        html = (DOCS / "index.html").read_text()
+        for tab in ["ci-health", "ci-analytics", "ci-queue", "test-parity"]:
+            assert f'data-tab="{tab}"' in html, f"missing tab: {tab}"
+
+    @pytest.mark.parametrize("f", [
+        "dashboard.js", "ci-health.js", "ci-analytics.js",
+        "ci-queue.js", "utils.js", "op-coverage.js"
+    ])
+    def test_js_exists(self, f):
+        assert (DOCS / "assets" / "js" / f).exists()
+
+    @pytest.mark.parametrize("f", [
+        "dashboard.js", "ci-health.js", "ci-analytics.js", "ci-queue.js", "utils.js"
+    ])
+    def test_js_braces_balanced(self, f):
+        c = (DOCS / "assets" / "js" / f).read_text()
+        assert c.count("{") == c.count("}"), f"{f}: unbalanced braces"
+
+    def test_css_exists(self):
+        assert (DOCS / "assets" / "css" / "dashboard.css").exists()
+
+    def test_css_has_sidebar(self):
+        css = (DOCS / "assets" / "css" / "dashboard.css").read_text()
+        assert "#sidebar" in css
+        assert ".overlay-backdrop" in css
+
+
+class TestShardMerging:
+    def _base(self, name):
+        n = re.sub(r'\s+\d+$', '', name)
+        n = re.sub(r'\s+\d+\s*:.*$', '', n)
+        n = re.sub(r'\s+\d+\)$', ')', n)
+        return n
+
+    def test_trailing_digit(self):
+        assert self._base("lora 1") == "lora"
+
+    def test_digit_colon(self):
+        assert self._base("mm (standard) 1: qwen2") == "mm (standard)"
+
+    def test_digit_paren(self):
+        assert self._base("mm (extended gen 1)") == "mm (extended gen)"
+
+    def test_preserved(self):
+        assert self._base("distributed tests (2 gpus)") == "distributed tests (2 gpus)"
+        assert self._base("basic correctness") == "basic correctness"
+
+    def test_reduces_real_data(self):
+        path = DATA / "vllm" / "ci" / "parity_report.json"
+        if not path.exists():
+            pytest.skip("no parity data")
+        groups = json.loads(path.read_text())["job_groups"]
+        merged = {self._base(g["name"]) for g in groups}
+        assert len(merged) < len(groups)
+
+
+class TestSiteAssembly:
+    def test_docs_data_exists(self):
+        assert (DOCS / "data").exists()
+
+    def test_projects_json(self):
+        p = DOCS / "_data" / "projects.json"
+        if not p.exists():
+            pytest.skip("not rendered yet")
+        assert "projects" in json.loads(p.read_text())


### PR DESCRIPTION
## Summary

- **37 tests** covering vLLM CI view integrity:
  - CI health data schema (pass rates, hardware breakdown, test counts)
  - Parity report structure (job groups, AMD/upstream side data)
  - Analytics data validation (pipeline summaries, build jobs)
  - Frontend file integrity (index.html elements, JS files exist)
  - JS brace balance (catches syntax errors)
  - Shard merging logic (trailing digits, digit:description, digit-paren patterns)
  - Site assembly (docs/data directory, projects.json)

- **CI workflow** (`.github/workflows/ci.yml`):
  - Runs on every PR and push to main
  - Three parallel jobs: `test` (pytest), `validate-frontend`, `validate-data`
  - Posts test results as a bot comment on PRs with pass/fail table
  - Tests **skip gracefully** if data files aren't collected yet — won't block PRs that don't touch CI data

- **Design principles**:
  - Only tests that protect vLLM CI view correctness
  - No tests that would make PRs harder to merge unnecessarily
  - Data schema tests ensure collection scripts don't break the frontend
  - Frontend tests ensure HTML/JS/CSS changes don't break rendering

## Test plan

- [x] All 37 tests pass locally
- [ ] CI workflow runs on this PR
- [ ] Bot comments test results on PR

Generated with [Claude Code](https://claude.com/claude-code)