### PR TITLE
[codex] Fix CI health group counts

### DIFF
--- a/docs/assets/js/ci-health.js
+++ b/docs/assets/js/ci-health.js
@@ -63,7 +63,10 @@
 
     // Use merged group counts
     const mergedGroups=parity?.job_groups?(typeof mergeShardedGroups==='function'?mergeShardedGroups(parity.job_groups):parity.job_groups):[];
-    const parityGroups=parity?.job_groups?(typeof mergeParityGroups==='function'?mergeParityGroups(parity.job_groups):mergedGroups):mergedGroups;
+    // Top-card coverage counts should remain group-level so:
+    // common + AMD-only == AMD unique test groups.
+    // Family-merged parity rows are still used in the detailed parity sections.
+    const coverageGroups=mergedGroups;
     const mergedAmdGroups=mergedGroups.filter(g=>g.amd).length;
     // A group is "failing" if it has ANY hard-fail signal — both pytest
     // ``failed`` assertions AND job-level ``error`` (timeouts, crashes,
@@ -101,16 +104,19 @@
 
     // Test groups card -> overlay with ALL groups (failing first, then passing)
     const allAmdGroups=mergedGroups.filter(g=>g.amd);
-    if(mergedAmdGroups) {
-      const groupRate=passingGroups.length/mergedAmdGroups;
-      const failCount=failingGroups.length;
-      const sub=`${passingGroups.length} passing${failCount>0?' &bull; <span style="color:'+C.r+'">'+failCount+' failing</span>':''}`;
-      row.append(card('Test Groups',`${passingGroups.length}/${mergedAmdGroups}`,sub,rc(groupRate),
-        ()=>showGroupOverlay_health('All Test Groups (AMD)',allAmdGroups,C.b,null,null,true)));
-    } else if(a.unique_test_groups) {
-      const orRate=a.test_groups_passing_or/a.unique_test_groups;
-      const sub=`${a.test_groups_passing_all} strict (all HW)${a.test_groups_partial>0?' &bull; <span style="color:'+C.y+'">'+a.test_groups_partial+' partial</span>':''}`;
-      row.append(card('Test Groups',`${a.test_groups_passing_or}/${a.unique_test_groups}`,sub,rc(orRate),
+    const amdTotalGroups=a.unique_test_groups||mergedAmdGroups||0;
+    if(amdTotalGroups) {
+      const amdPassAny=a.test_groups_passing_or ?? passingGroups.length;
+      const amdPassAll=a.test_groups_passing_all ?? passingGroups.length;
+      const amdPartial=a.test_groups_partial ?? Math.max(0, amdPassAny-amdPassAll);
+      const amdFailAll=Math.max(0, amdTotalGroups-amdPassAny);
+      const groupRate=amdPassAny/amdTotalGroups;
+      const sub=[
+        `${amdPassAll} strict all-HW`,
+        amdPartial>0?`<span style="color:${C.y}">${amdPartial} partial</span>`:'',
+        amdFailAll>0?`<span style="color:${C.r}">${amdFailAll} failing</span>`:'',
+      ].filter(Boolean).join(' &bull; ');
+      row.append(card('Test Groups',`${amdPassAny}/${amdTotalGroups}`,sub,rc(groupRate),
         ()=>showGroupOverlay_health('All Test Groups (AMD)',allAmdGroups,C.b,null,null,true)));
     } else {
       row.append(card('Test Groups',mergedAmdGroups||a.test_groups,`${a.jobs_passed||0} jobs passed`,C.b,
@@ -119,9 +125,10 @@
 
     // Parity card -> overlay with 3-tab parity breakdown
     if(mergedGroups.length) {
-      const bothGroups=parityGroups.filter(g=>g.amd&&g.upstream);
-      const aOnlyGroups=parityGroups.filter(g=>g.amd&&!g.upstream);
-      const uOnlyGroups=parityGroups.filter(g=>!g.amd&&g.upstream);
+      const hasUpstreamCoverage=g=>!!g.upstream||g.status==='upstream_only'||g.backfilled||g.hw_backfilled;
+      const bothGroups=coverageGroups.filter(g=>g.amd&&g.upstream);
+      const aOnlyGroups=coverageGroups.filter(g=>g.amd&&!g.upstream);
+      const uOnlyGroups=coverageGroups.filter(g=>!g.amd&&hasUpstreamCoverage(g));
       row.append(card('Coverage Parity',`${bothGroups.length} common`,`${aOnlyGroups.length} AMD-only &bull; ${uOnlyGroups.length} upstream-only`,C.p,
         ()=>showParityOverlay(bothGroups,aOnlyGroups,uOnlyGroups)));
     } else if(u) {

--- a/tests/vllm/test_dashboard_smoke.py
+++ b/tests/vllm/test_dashboard_smoke.py
@@ -177,6 +177,15 @@ class TestJsFileShape:
             "ci-health.js should use canonical parity families in its parity-focused sections"
         )
 
+    def test_ci_health_top_cards_use_consistent_group_denominators(self):
+        text = (JS / "ci-health.js").read_text()
+        assert "const amdTotalGroups=a.unique_test_groups||mergedAmdGroups||0" in text
+        assert "const amdPassAny=a.test_groups_passing_or ?? passingGroups.length" in text
+        assert "card('Test Groups',`${amdPassAny}/${amdTotalGroups}`" in text
+        assert "const coverageGroups=mergedGroups" in text
+        assert "const hasUpstreamCoverage=g=>!!g.upstream||g.status==='upstream_only'" in text
+        assert "bothGroups=coverageGroups.filter" in text
+
     def test_fetchjson_catches_rejected_fetches(self):
         text = (JS / "utils.js").read_text()
         m = re.search(

--- a/tests/vllm/test_rendering_data.py
+++ b/tests/vllm/test_rendering_data.py
@@ -185,6 +185,47 @@ class TestJSRenderingSafety:
                 if tgp is not None:
                     assert isinstance(tgp, int), f"Build #{b.get('build_number')} test_groups_passing_or is {type(tgp)}"
 
+    def test_ci_health_group_pass_math_is_self_consistent(self):
+        """Passing-any-HW is strict all-HW plus partial groups."""
+        path = DATA / "vllm" / "ci" / "ci_health.json"
+        if not path.exists():
+            pytest.skip("no ci_health")
+        d = json.loads(path.read_text())
+        for section in ["amd", "upstream"]:
+            builds = (d.get(section) or {}).get("builds", [])
+            for b in builds:
+                total = b.get("unique_test_groups") or 0
+                passing_or = b.get("test_groups_passing_or") or 0
+                passing_all = b.get("test_groups_passing_all") or 0
+                partial = b.get("test_groups_partial") or 0
+                assert passing_or == passing_all + partial, (
+                    f"{section} build #{b.get('build_number')} has inconsistent group pass math"
+                )
+                assert 0 <= passing_or <= total, (
+                    f"{section} build #{b.get('build_number')} passing groups out of range"
+                )
+
+    def test_runtime_parity_counts_cover_latest_amd_groups(self):
+        """Group-level common + AMD-only parity rows should equal AMD unique groups."""
+        health_path = DATA / "vllm" / "ci" / "ci_health.json"
+        parity_path = DATA / "vllm" / "ci" / "parity_report.json"
+        if not health_path.exists() or not parity_path.exists():
+            pytest.skip("no CI parity data")
+        health = json.loads(health_path.read_text())
+        parity = json.loads(parity_path.read_text())
+        latest_amd = (health.get("amd") or {}).get("latest_build") or {}
+        amd_total = latest_amd.get("unique_test_groups")
+        if amd_total is None:
+            pytest.skip("latest AMD build has no unique group count")
+
+        groups = parity.get("job_groups") or []
+        common = sum(1 for g in groups if g.get("amd") and g.get("upstream"))
+        amd_only = sum(1 for g in groups if g.get("amd") and not g.get("upstream"))
+        assert common + amd_only == amd_total, (
+            f"runtime parity common+AMD-only ({common}+{amd_only}) must equal "
+            f"latest AMD unique test groups ({amd_total})"
+        )
+
 
 class TestNoJobStateMismatch:
     """Tests that passed jobs are not reported as failed."""


### PR DESCRIPTION
## Summary

- Display the CI Health Test Groups headline from the backend group pass fields, so partial hardware passes count correctly as passing-any-HW groups.
- Use group-level parity rows for the top Coverage Parity card instead of family-collapsed rows, so common + AMD-only matches the latest AMD unique group count.
- Add regression tests for the group pass math and parity-card denominator consistency.

## Root Cause

The backend summary for AMD build 8682 was correct: 81 of 133 unique groups had at least one hardware pass, 74 passed on all hardware, and 7 were partial. The frontend headline card was using strict all-hardware parity rows, which made it show 74/133 instead of the backend passing-any-HW value.

The Coverage Parity card was using family-merged parity rows, so it showed 114 common groups even though group-level parity is 125 common + 8 AMD-only = 133 AMD groups.

## Validation

- `nix develop .#minimal -c pytest tests/vllm/test_dashboard_smoke.py::TestJsFileShape::test_ci_health_top_cards_use_consistent_group_denominators tests/vllm/test_rendering_data.py::TestJSRenderingSafety::test_ci_health_group_pass_math_is_self_consistent tests/vllm/test_rendering_data.py::TestJSRenderingSafety::test_runtime_parity_counts_cover_latest_amd_groups -q`
- `nix develop .#minimal -c pytest -q`