### PR TITLE
Prevent false PR links from blocking dashboard refresh

### DIFF
--- a/scripts/collect.py
+++ b/scripts/collect.py
@@ -23,6 +23,10 @@ _PULL_URL_RE = re.compile(
     r"https?://github\.com/([^/\s]+/[^/\s]+)/pull/(\d+)",
     re.IGNORECASE,
 )
+_BUILDKITE_BUILD_URL_RE = re.compile(
+    r"https?://buildkite\.com/[^/\s)]+/[^/\s)]+/builds/(\d+)",
+    re.IGNORECASE,
+)
 _PR_CONTEXT_REF_RE = re.compile(
     r"(?i)\b(?:pr|pull request|pull)\b[^\n#]{0,160}#(\d+)"
 )
@@ -577,9 +581,13 @@ def fetch_issue_comments(repo, number):
 
 def extract_pr_refs(text, default_repo):
     """Extract GitHub PR references from issue text/comment text."""
+    body = text or ""
     refs = []
     seen = set()
-    for match in _PULL_URL_RE.finditer(text or ""):
+    buildkite_build_numbers = {
+        int(match.group(1)) for match in _BUILDKITE_BUILD_URL_RE.finditer(body)
+    }
+    for match in _PULL_URL_RE.finditer(body):
         repo = match.group(1)
         number = int(match.group(2))
         key = (repo.lower(), number)
@@ -591,8 +599,14 @@ def extract_pr_refs(text, default_repo):
             "number": number,
             "url": f"https://github.com/{repo}/pull/{number}",
         })
-    for match in _PR_CONTEXT_REF_RE.finditer(text or ""):
+    for match in _PR_CONTEXT_REF_RE.finditer(body):
         number = int(match.group(1))
+        # CI issue prose sometimes calls a Buildkite run "PR #<build>".  An
+        # explicit GitHub pull URL above remains authoritative, but a bare
+        # heuristic reference must not turn a demonstrated Buildkite build ID
+        # into a fabricated same-repository pull request.
+        if number in buildkite_build_numbers:
+            continue
         key = (default_repo.lower(), number)
         if key in seen:
             continue
@@ -603,6 +617,47 @@ def extract_pr_refs(text, default_repo):
             "url": f"https://github.com/{default_repo}/pull/{number}",
         })
     return refs
+
+
+def resolve_project_issue_pr_refs(repo, issues, prs):
+    """Retain same-repo issue links only when GitHub confirms the PR exists.
+
+    Textual ``PR #N`` references are necessarily heuristic.  A missing or
+    non-PR target should make that optional Home-page relationship disappear
+    for this collection, not leave ``issues.json`` inconsistent with
+    ``prs.json`` and freeze publication of unrelated CI-health data.
+    """
+    pr_by_number = {
+        pr.get("number"): pr
+        for pr in prs
+        if isinstance(pr, dict) and isinstance(pr.get("number"), int)
+    }
+    repo_norm = repo.lower()
+
+    for issue in issues:
+        valid_refs = []
+        for ref in issue.get("linked_prs") or []:
+            if not isinstance(ref, dict):
+                continue
+            ref_repo = (ref.get("repo") or repo).lower()
+            if ref_repo != repo_norm:
+                valid_refs.append(ref)
+                continue
+            number = ref.get("number")
+            if not isinstance(number, int):
+                continue
+            if number not in pr_by_number:
+                pr = fetch_pr_by_number(repo, number)
+                if not pr:
+                    print(
+                        f"  WARNING: Ignoring unresolved PR reference #{number} "
+                        f"from project issue #{issue.get('number')}"
+                    )
+                    continue
+                prs.append(pr)
+                pr_by_number[number] = pr
+            valid_refs.append(ref)
+        issue["linked_prs"] = valid_refs
 
 
 def enrich_project_issues_with_linked_prs(repo, issues):
@@ -807,21 +862,11 @@ def collect_project(name, cfg):
                 prs.append(pr)
                 existing_nums.add(number)
 
-    # Guarantee that PRs referenced from any open project #39 issue body or
-    # comment are present and tagged as CI PRs.
+    # Resolve heuristic references from project #39 issue prose.  Only
+    # GitHub-confirmed same-repo PRs survive into issues.json, and every
+    # retained PR is present in prs.json for the cross-surface audit.
     if project_issues:
-        existing_nums = {p["number"] for p in prs}
-        for issue in project_issues:
-            for ref in issue.get("linked_prs") or []:
-                if (ref.get("repo") or repo).lower() != repo.lower():
-                    continue
-                number = ref.get("number")
-                if not isinstance(number, int) or number in existing_nums:
-                    continue
-                pr = fetch_pr_by_number(repo, number)
-                if pr:
-                    prs.append(pr)
-                    existing_nums.add(number)
+        resolve_project_issue_pr_refs(repo, project_issues, prs)
 
     apply_pr_tags(prs, project_issues, repo)
     prs = sorted(prs, key=lambda p: p["updated_at"], reverse=True)

--- a/scripts/vllm/sync_ready_tickets.py
+++ b/scripts/vllm/sync_ready_tickets.py
@@ -673,6 +673,10 @@ _HW_PREFIX_RE = re.compile(r"^mi\d+_\d+:\s*", re.IGNORECASE)
 _HW_PREFIX_CAPTURE_RE = re.compile(r"^(mi\d+_\d+):\s*", re.IGNORECASE)
 _CI_PREFIX_RE = re.compile(r"^\[CI Failure\]:\s*", re.IGNORECASE)
 _PULL_URL_RE = re.compile(r"https?://github\.com/([^/\s]+/[^/\s]+)/pull/(\d+)", re.IGNORECASE)
+_BUILDKITE_BUILD_URL_RE = re.compile(
+    r"https?://buildkite\.com/[^/\s)]+/[^/\s)]+/builds/(\d+)",
+    re.IGNORECASE,
+)
 _PR_CONTEXT_REF_RE = re.compile(
     r"(?i)\b(?:pr|pull request|expected to be solved after|solved after)\b[^\n#]{0,120}#(\d+)"
 )
@@ -1076,6 +1080,9 @@ def _extract_linked_prs_from_text(text: str, repo_full_name: str) -> list[dict]:
     refs: dict[int, dict] = {}
     body = text or ""
     repo_norm = (repo_full_name or "").lower()
+    buildkite_build_numbers = {
+        int(match.group(1)) for match in _BUILDKITE_BUILD_URL_RE.finditer(body)
+    }
 
     for match in _PULL_URL_RE.finditer(body):
         repo = match.group(1)
@@ -1089,6 +1096,8 @@ def _extract_linked_prs_from_text(text: str, repo_full_name: str) -> list[dict]:
 
     for match in _PR_CONTEXT_REF_RE.finditer(body):
         number = int(match.group(1))
+        if number in buildkite_build_numbers:
+            continue
         refs.setdefault(number, {
             "number": number,
             "url": f"https://github.com/{repo_full_name}/pull/{number}",

--- a/tests/vllm/test_collect_pr_issue_filter.py
+++ b/tests/vllm/test_collect_pr_issue_filter.py
@@ -112,6 +112,60 @@ SEARCH_ISSUES_PR_SHAPE = {
 }
 
 
+class TestLinkedPrReferences:
+    def test_buildkite_build_labeled_as_pr_is_not_a_github_reference(self):
+        repo = "vllm-project/vllm"
+        text = (
+            "[PR #82340](https://buildkite.com/vllm/ci/builds/82340#job) failed\n"
+            "PR #82340 (retry) also failed\n"
+            "PR for this here #40176\n"
+        )
+
+        assert collect.extract_pr_refs(text, repo) == [{
+            "repo": repo,
+            "number": 40176,
+            "url": "https://github.com/vllm-project/vllm/pull/40176",
+        }]
+
+    def test_unresolved_heuristic_reference_is_pruned_before_publication(
+        self, monkeypatch, capsys
+    ):
+        repo = "vllm-project/vllm"
+        confirmed_raw = dict(REAL_PR)
+        confirmed_raw.update({
+            "number": 49937,
+            "html_url": f"https://github.com/{repo}/pull/49937",
+        })
+        confirmed_pr = collect.normalize_pr(confirmed_raw)
+        issues = [{
+            "number": 51115,
+            "linked_prs": [
+                {
+                    "repo": repo,
+                    "number": 49937,
+                    "url": f"https://github.com/{repo}/pull/49937",
+                },
+                {
+                    "repo": repo,
+                    "number": 82340,
+                    "url": f"https://github.com/{repo}/pull/82340",
+                },
+            ],
+        }]
+        prs = []
+        monkeypatch.setattr(
+            collect,
+            "fetch_pr_by_number",
+            lambda _repo, number: confirmed_pr if number == 49937 else None,
+        )
+
+        collect.resolve_project_issue_pr_refs(repo, issues, prs)
+
+        assert [ref["number"] for ref in issues[0]["linked_prs"]] == [49937]
+        assert [pr["number"] for pr in prs] == [49937]
+        assert "Ignoring unresolved PR reference #82340" in capsys.readouterr().out
+
+
 # ---------------------------------------------------------------------------
 # Fake ``gh_api`` — returns specific payloads per endpoint prefix.
 # ---------------------------------------------------------------------------

--- a/tests/vllm/test_sync_ready_tickets.py
+++ b/tests/vllm/test_sync_ready_tickets.py
@@ -224,6 +224,29 @@ class TestLinkedPrExtraction:
             {"number": 40176, "url": "https://github.com/vllm-project/vllm/pull/40176"},
         ]
 
+    def test_ignores_buildkite_build_numbers_labeled_as_prs(self):
+        repo = "vllm-project/vllm"
+        text = (
+            "[PR #82340](https://buildkite.com/vllm/ci/builds/82340#job) failed\n"
+            "PR #82340 (retry) also failed\n"
+            "PR for this here #40176\n"
+        )
+
+        assert srt._extract_linked_prs_from_text(text, repo) == [
+            {"number": 40176, "url": "https://github.com/vllm-project/vllm/pull/40176"},
+        ]
+
+    def test_explicit_github_pull_url_wins_over_buildkite_number_collision(self):
+        repo = "vllm-project/vllm"
+        text = (
+            "PR #82340 ran at https://buildkite.com/vllm/ci/builds/82340\n"
+            "Actual pull: https://github.com/vllm-project/vllm/pull/82340\n"
+        )
+
+        assert srt._extract_linked_prs_from_text(text, repo) == [
+            {"number": 82340, "url": "https://github.com/vllm-project/vllm/pull/82340"},
+        ]
+
 
 class TestNormalizeTitle:
     # Secondary lookup so a hand-filed ``[CI Failure]: Transformers ...``


### PR DESCRIPTION
## What changed

- distinguish Buildkite build numbers from heuristic `PR #N` references in both issue collectors
- require GitHub to confirm same-repository pull requests before retaining those links in published issue data
- add regression coverage for issue #51115 / Buildkite build #82340 and explicit URL collisions

## Root cause

Issue `vllm-project/vllm#51115` labels Buildkite build `#82340` as a PR in its prose. The collector fabricated GitHub PR `#82340`, which does not exist. The strict cross-surface audit then rejected `issues.json` because `prs.json` correctly omitted it, blocking commit and GitHub Pages deployment after fresh CI data had already been collected.

## Impact

Fresh CI data can publish automatically again without weakening the strict dashboard audit. Ambiguous or unresolved heuristic PR links are omitted for that collection, while explicit GitHub pull URLs remain authoritative.

## Validation

- `ruff check scripts tests`
- `pytest tests/ -q` — 1696 passed, 14 skipped
- live issue #51115 extraction resolves only real PR #49937