### PR TITLE
Stabilize hourly dashboard refresh

### DIFF
--- a/.github/workflows/hourly-master.yml
+++ b/.github/workflows/hourly-master.yml
@@ -6,7 +6,10 @@ name: Data Collection
 # Those workflows keep their workflow_dispatch triggers for manual runs.
 on:
   schedule:
-    - cron: '13,43 * * * *'  # Every 30 min at :13,:43
+    # The full collection regularly takes about 25 minutes. Run it hourly so
+    # delayed schedules cannot bunch up behind the non-canceling deploy lock.
+    # Lightweight queue monitoring remains on its separate 10-minute cadence.
+    - cron: '13 * * * *'
   repository_dispatch:
     types: [buildkite_build_finished, perf_eval_build_finished]
   workflow_dispatch:

--- a/docs/assets/js/ops-v2.js
+++ b/docs/assets/js/ops-v2.js
@@ -5833,7 +5833,16 @@
   }
 
   function combineComparisonSides(rows, sideName) {
-    const sides = rows.map(function (row) { return row[sideName] || {}; });
+    const seenGroupSets = new Set();
+    const sides = [];
+    rows.forEach(function (row) {
+      const side = row[sideName] || {};
+      const groupIds = (side.group_ids || []).slice().sort();
+      const identity = groupIds.length ? groupIds.join('|') : String(row.id || '') + ':' + sideName;
+      if (seenGroupSets.has(identity)) return;
+      seenGroupSets.add(identity);
+      sides.push(side);
+    });
     const runs = sides.reduce(function (sum, side) { return sum + Number(side.runs || 0); }, 0);
     const incidents = sides.reduce(function (sum, side) { return sum + Number(side.incidents || 0); }, 0);
     const children = sides.reduce(function (sum, side) { return sum + Number(side.child_retry_attempts || 0); }, 0);
@@ -6146,7 +6155,7 @@
     const windowInfo = comparison.window || {};
     analyticsWindowControl(host, comparison);
     host.append(statusStrip([
-      {label: 'ACTIVE AMD GROUPS', value: integer(active.length) + ' / ' + integer(summary.amd_base_group_count), meta: integer(amd.runs) + ' exact attempts in ' + state.analyticsWindow, onOpen: function () { openTableBrowser({id: 'flake-comparison-all', title: 'AMD and CUDA incident comparison', subtitle: state.analyticsWindow + ' upstream branch=main window', rows: sorted, columns: comparisonFlakeColumns(ops, reliability, retry), searchText: comparisonSearchText, geometry: {name: 'flake-comparison', minWidth: '1260px'}}); }},
+      {label: 'ACTIVE AMD VARIANTS', value: integer(active.length) + ' / ' + integer(summary.amd_comparison_row_count || summary.amd_base_group_count), meta: integer(amd.runs) + ' exact attempts in ' + state.analyticsWindow, onOpen: function () { openTableBrowser({id: 'flake-comparison-all', title: 'AMD and CUDA incident comparison', subtitle: state.analyticsWindow + ' upstream branch=main window', rows: sorted, columns: comparisonFlakeColumns(ops, reliability, retry), searchText: comparisonSearchText, geometry: {name: 'flake-comparison', minWidth: '1260px'}}); }},
       {label: 'AMD INCIDENTS', value: integer(amd.incidents), meta: comparisonPercent(amd, 'incident_rate_pct') + ' of ' + integer(amd.runs) + ' attempts', tone: Number(amd.incidents) ? 'is-warning' : 'is-success'},
       {label: 'REGRESSED VS PRIOR', value: windowInfo.completeAggregate ? '-' : integer(summary.regressed_incident_group_count), meta: windowInfo.completeAggregate ? 'choose 1h-7d for movement' : integer(summary.new_incident_group_count) + ' newly incident groups', tone: Number(summary.regressed_incident_group_count) ? 'is-danger' : 'is-success'},
       {label: 'PAIRED AMD / CUDA', value: comparisonPercent(pairedAmd, 'incident_rate_pct') + ' / ' + comparisonPercent(cuda, 'incident_rate_pct'), meta: integer(comparable.length) + ' active exact pairs'},
@@ -6173,7 +6182,7 @@
       evidenceSummary: function (row) { return comparisonPercent(row.amd, 'incident_rate_pct') + ' AMD - ' + comparisonPercent(row.cuda, 'incident_rate_pct') + ' CUDA'; },
       ops: ops, reliability: reliability, retry: retry, focus: 'flakes',
     });
-    host.append(compactTablePanel('AMD incident comparison', integer(active.length) + ' active AMD groups - ' + integer(comparable.length) + ' active exact CUDA pairs', comparisonFlakeColumns(ops, reliability, retry), sorted, {
+    host.append(compactTablePanel('AMD incident comparison', integer(active.length) + ' active AMD variant rows - ' + integer(comparable.length) + ' active exact CUDA pairs', comparisonFlakeColumns(ops, reliability, retry), sorted, {
       id: 'flake-comparison-browser',
       limit: 12,
       alwaysBrowse: true,
@@ -6263,7 +6272,7 @@
       {label: 'AMD / CUDA gap', numeric: true, width: '120px', render: function (row) { const control = linkButton(comparisonDelta(row.retry_frequency_delta_pp, ' pp'), function () { openPlatformComparisonDetail(row, ops, reliability, retry, 'retries'); }); control.classList.add('ops-comparison-delta', comparisonTone(row.retry_frequency_delta_pp, 2)); return control; }},
       {label: 'Evidence', width: '90px', render: function (row) { return linkButton('Inspect', function () { openPlatformComparisonDetail(row, ops, reliability, retry, 'retries'); }, 'Inspect exact retry attempts and recoveries'); }},
     ];
-    host.append(compactTablePanel('AMD retry comparison', integer(active.length) + ' active AMD groups - ' + integer(comparable.length) + ' active exact CUDA pairs', columns, sorted, {
+    host.append(compactTablePanel('AMD retry comparison', integer(active.length) + ' active AMD variant rows - ' + integer(comparable.length) + ' active exact CUDA pairs', columns, sorted, {
       id: 'retry-comparison-browser',
       limit: 12,
       alwaysBrowse: true,

--- a/scripts/vllm/audit_dashboard_data.py
+++ b/scripts/vllm/audit_dashboard_data.py
@@ -1524,6 +1524,116 @@ class DashboardAudit:
             for row in catalog
             if isinstance(row, dict) and row.get("id")
         }
+        comparison = _mapping(reliability.get("platform_comparison"))
+        comparison_rows = [
+            row
+            for row in _rows(comparison.get("rows"))
+            if isinstance(row, dict)
+        ]
+        comparison_summary = _mapping(comparison.get("summary"))
+        comparison_keys = {
+            str(row.get("comparison_key") or "")
+            for row in comparison_rows
+            if row.get("comparison_key")
+        }
+        eligible_comparison_rows = [
+            row for row in comparison_rows if row.get("comparison_eligible") is True
+        ]
+        matched_comparison_keys = {
+            str(row.get("comparison_key") or "")
+            for row in eligible_comparison_rows
+            if row.get("comparison_key")
+        }
+        label_matched_keys = {
+            str(row.get("comparison_key") or "")
+            for row in comparison_rows
+            if row.get("comparison_key")
+            and _safe_int(_mapping(row.get("cuda")).get("variant_count")) > 0
+        }
+        comparison_amd_ids = {
+            str(group_id)
+            for row in comparison_rows
+            for group_id in _rows(_mapping(row.get("amd")).get("group_ids"))
+            if group_id
+        }
+        matched_cuda_ids = {
+            str(group_id)
+            for row in eligible_comparison_rows
+            for group_id in _rows(_mapping(row.get("cuda")).get("group_ids"))
+            if group_id
+        }
+        comparison_counts = {
+            "amd_base_group_count": len(comparison_keys),
+            "amd_variant_count": len(comparison_amd_ids),
+            "label_matched_base_group_count": len(label_matched_keys),
+            "matched_base_group_count": len(matched_comparison_keys),
+            "comparable_base_group_count": len(matched_comparison_keys),
+            "review_required_base_group_count": (
+                len(comparison_keys) - len(matched_comparison_keys)
+            ),
+            "unmatched_amd_base_group_count": (
+                len(comparison_keys) - len(label_matched_keys)
+            ),
+            "matched_cuda_variant_count": len(matched_cuda_ids),
+        }
+        if comparison:
+            mismatched_counts = {
+                key: (comparison_summary.get(key), expected)
+                for key, expected in comparison_counts.items()
+                if _safe_int(comparison_summary.get(key), -1) != expected
+            }
+            if "amd_comparison_row_count" in comparison_summary and _safe_int(
+                comparison_summary.get("amd_comparison_row_count"), -1
+            ) != len(comparison_rows):
+                mismatched_counts["amd_comparison_row_count"] = (
+                    comparison_summary.get("amd_comparison_row_count"),
+                    len(comparison_rows),
+                )
+            if "comparable_variant_pair_count" in comparison_summary and _safe_int(
+                comparison_summary.get("comparable_variant_pair_count"), -1
+            ) != len(eligible_comparison_rows):
+                mismatched_counts["comparable_variant_pair_count"] = (
+                    comparison_summary.get("comparable_variant_pair_count"),
+                    len(eligible_comparison_rows),
+                )
+            if mismatched_counts:
+                self.error(
+                    "operations-platform-comparison-counts",
+                    (
+                        "platform_comparison summary does not reconcile with its "
+                        f"published rows: {mismatched_counts}"
+                    ),
+                    relpath,
+                )
+            invalid_pairs = [
+                row
+                for row in comparison_rows
+                if (
+                    row.get("comparison_eligible") is True
+                    and (
+                        row.get("match_status") != "exact_cuda_pair"
+                        or _safe_int(_mapping(row.get("amd")).get("variant_count")) != 1
+                        or _safe_int(_mapping(row.get("cuda")).get("variant_count")) != 1
+                    )
+                )
+                or (
+                    row.get("comparison_eligible") is not True
+                    and row.get("match_status") == "exact_cuda_pair"
+                )
+            ]
+            missing_catalog_ids = (
+                comparison_amd_ids | matched_cuda_ids
+            ) - set(catalog_by_id)
+            if invalid_pairs or missing_catalog_ids:
+                self.error(
+                    "operations-platform-comparison-eligibility",
+                    (
+                        f"{len(invalid_pairs)} comparison rows violate exact-pair "
+                        f"eligibility and {len(missing_catalog_ids)} referenced group "
+                        "IDs are absent from the reliability catalog"
+                    ),
+                    relpath,
+                )
         candidates = _rows(reliability.get("flaky_candidates"))
         cohort_build_numbers = {
             _safe_int(number, -1)
@@ -1840,6 +1950,8 @@ class DashboardAudit:
             "other_main_builds": cohort_other_main,
             "retry_attempts": len(retry_attempts),
             "retry_recoveries": len(recoveries),
+            "platform_comparison_base_groups": len(comparison_keys),
+            "platform_comparison_variant_pairs": len(eligible_comparison_rows),
             "source_age_hours": source_ages,
         }
 

--- a/scripts/vllm/build_operations_snapshot.py
+++ b/scripts/vllm/build_operations_snapshot.py
@@ -1994,7 +1994,8 @@ def _platform_comparison(
     cohort_builds: int,
 ) -> dict:
     grouped: dict[tuple[str, str], list[dict]] = defaultdict(list)
-    exact_identity: dict[str, tuple[str, str]] = {}
+    exact_identity: dict[str, tuple[str, str, str]] = {}
+    catalog_identity: dict[str, tuple[str, str, str]] = {}
     for row in catalog:
         platform = _comparison_platform(row)
         if platform not in {"amd", "cuda"}:
@@ -2003,22 +2004,31 @@ def _platform_comparison(
         if not key:
             continue
         grouped[(platform, key)].append(row)
+        group_id = str(row.get("id") or "")
+        if group_id:
+            catalog_identity[group_id] = (platform, key, group_id)
         for identity in [row.get("name"), *(row.get("raw_names") or [])]:
             if identity:
-                exact_identity[str(identity).casefold()] = (platform, key)
+                exact_identity[str(identity).casefold()] = (platform, key, group_id)
 
-    def retry_identity(row: dict) -> tuple[str, str] | None:
+    def retry_identity(row: dict) -> tuple[str, str, str] | None:
+        group_id = str(row.get("group_id") or "")
+        if group_id and group_id in catalog_identity:
+            return catalog_identity[group_id]
         name = str(row.get("name") or "")
         exact = exact_identity.get(name.casefold())
         if exact:
             return exact
         key = _comparison_key(name)
         platform = "amd" if AMD_PREFIX_RE.match(name) else "cuda"
-        return (platform, key) if grouped.get((platform, key)) else None
+        candidates = grouped.get((platform, key)) or []
+        if len(candidates) != 1:
+            return None
+        return (platform, key, str(candidates[0].get("id") or ""))
 
-    retry_involved_counts: Counter[tuple[str, str]] = Counter()
-    child_retry_counts: Counter[tuple[str, str]] = Counter()
-    recovery_counts: Counter[tuple[str, str]] = Counter()
+    retry_involved_counts: Counter[tuple[str, str, str]] = Counter()
+    child_retry_counts: Counter[tuple[str, str, str]] = Counter()
+    recovery_counts: Counter[tuple[str, str, str]] = Counter()
     if retry_analysis.get("available") is True:
         for row in retry_analysis.get("retry_attempts") or []:
             if identity := retry_identity(row):
@@ -2029,31 +2039,37 @@ def _platform_comparison(
             if identity := retry_identity(row):
                 recovery_counts[identity] += 1
 
+    def group_count(
+        counter: Counter[tuple[str, str, str]],
+        platform: str,
+        key: str,
+        groups: list[dict],
+    ) -> int:
+        return sum(
+            counter[(platform, key, str(group.get("id") or ""))]
+            for group in groups
+        )
+
+    def counter_total(
+        counter: Counter[tuple[str, str, str]],
+        platform: str,
+        keys: set[str],
+    ) -> int:
+        return sum(
+            count
+            for (item_platform, key, _), count in counter.items()
+            if item_platform == platform and key in keys
+        )
+
     amd_keys = sorted(key for platform, key in grouped if platform == "amd")
     rows = []
     for key in amd_keys:
         amd_groups = grouped[("amd", key)]
         cuda_groups = grouped.get(("cuda", key), [])
-        amd = _comparison_side(
-            amd_groups,
-            cohort_builds,
-            child_retry_counts[("amd", key)],
-            recovery_counts[("amd", key)],
-            retry_involved_counts[("amd", key)],
-        )
-        cuda = _comparison_side(
-            cuda_groups,
-            cohort_builds,
-            child_retry_counts[("cuda", key)],
-            recovery_counts[("cuda", key)],
-            retry_involved_counts[("cuda", key)],
-        )
         label = _comparison_label(amd_groups[0].get("name"))
         match_issues = []
         if not cuda_groups:
             match_issues.append("no_cuda_equivalent")
-        if len(amd_groups) > 1:
-            match_issues.append("shared_amd_base_label")
         if len(cuda_groups) > 1:
             match_issues.append("ambiguous_cuda_variants")
         if cuda_groups and any(
@@ -2062,68 +2078,104 @@ def _platform_comparison(
             match_issues.append("generic_or_unsupported_gpu_reference")
         if HARDWARE_WORD_RE.search(label):
             match_issues.append("hardware_specific_label")
-        comparison_eligible = not match_issues
-        match_status = "exact_cuda_pair" if comparison_eligible else match_issues[0]
-        rows.append({
-            "id": hashlib.sha1(f"ci-amd-cuda:{key}".encode()).hexdigest()[:20],
-            "label": label,
-            "comparison_key": key,
-            "match_status": match_status,
-            "match_issues": match_issues,
-            "comparison_eligible": comparison_eligible,
-            "amd": amd,
-            "cuda": cuda,
-            "incident_rate_delta_pp": (
-                round(float(amd["incident_rate_pct"]) - float(cuda["incident_rate_pct"]), 1)
-                if comparison_eligible and amd["incident_rate_pct"] is not None and cuda["incident_rate_pct"] is not None
-                else None
-            ),
-            "retry_frequency_delta_pp": (
-                round(float(amd["retry_frequency_pct"]) - float(cuda["retry_frequency_pct"]), 1)
-                if comparison_eligible and amd["retry_frequency_pct"] is not None and cuda["retry_frequency_pct"] is not None
-                else None
-            ),
-            "worst_p90_delta_mins": (
-                round(float(amd["worst_p90_duration_mins"]) - float(cuda["worst_p90_duration_mins"]), 1)
-                if comparison_eligible and amd["worst_p90_duration_mins"] is not None and cuda["worst_p90_duration_mins"] is not None
-                else None
-            ),
-        })
+
+        # A base label can legitimately run on several AMD hardware variants.
+        # Keep the comparison one-to-one by emitting one row per AMD variant
+        # when there is exactly one explicit CUDA reference. Previously the
+        # arrival of a second AMD variant invalidated the whole base label and
+        # could drive every comparison count to zero during a live refresh.
+        selections = (
+            [([amd_group], cuda_groups, []) for amd_group in amd_groups]
+            if not match_issues
+            else [(amd_groups, cuda_groups, match_issues)]
+        )
+        for selected_amd, selected_cuda, row_issues in selections:
+            comparison_eligible = not row_issues
+            match_status = "exact_cuda_pair" if comparison_eligible else row_issues[0]
+            amd = _comparison_side(
+                selected_amd,
+                cohort_builds,
+                group_count(child_retry_counts, "amd", key, selected_amd),
+                group_count(recovery_counts, "amd", key, selected_amd),
+                group_count(retry_involved_counts, "amd", key, selected_amd),
+            )
+            cuda = _comparison_side(
+                selected_cuda,
+                cohort_builds,
+                group_count(child_retry_counts, "cuda", key, selected_cuda),
+                group_count(recovery_counts, "cuda", key, selected_cuda),
+                group_count(retry_involved_counts, "cuda", key, selected_cuda),
+            )
+            variant_id = (
+                str(selected_amd[0].get("id") or "")
+                if comparison_eligible
+                else "review"
+            )
+            rows.append({
+                "id": hashlib.sha1(
+                    f"ci-amd-cuda:{key}:{variant_id}".encode()
+                ).hexdigest()[:20],
+                "label": label,
+                "comparison_key": key,
+                "match_status": match_status,
+                "match_issues": row_issues,
+                "comparison_eligible": comparison_eligible,
+                "amd": amd,
+                "cuda": cuda,
+                "incident_rate_delta_pp": (
+                    round(float(amd["incident_rate_pct"]) - float(cuda["incident_rate_pct"]), 1)
+                    if comparison_eligible and amd["incident_rate_pct"] is not None and cuda["incident_rate_pct"] is not None
+                    else None
+                ),
+                "retry_frequency_delta_pp": (
+                    round(float(amd["retry_frequency_pct"]) - float(cuda["retry_frequency_pct"]), 1)
+                    if comparison_eligible and amd["retry_frequency_pct"] is not None and cuda["retry_frequency_pct"] is not None
+                    else None
+                ),
+                "worst_p90_delta_mins": (
+                    round(float(amd["worst_p90_duration_mins"]) - float(cuda["worst_p90_duration_mins"]), 1)
+                    if comparison_eligible and amd["worst_p90_duration_mins"] is not None and cuda["worst_p90_duration_mins"] is not None
+                    else None
+                ),
+            })
     rows.sort(
         key=lambda row: (
             -(float(row["amd"].get("incident_rate_pct") or 0)),
             str(row.get("label") or "").casefold(),
         )
     )
-    label_matched = [row for row in rows if row["cuda"]["variant_count"]]
     matched = [row for row in rows if row["comparison_eligible"]]
     amd_groups = [row for (platform, _), values in grouped.items() if platform == "amd" for row in values]
+    matched_keys = {row["comparison_key"] for row in matched}
+    label_matched_keys = {
+        key for key in amd_keys if grouped.get(("cuda", key))
+    }
     matched_cuda_groups = [
         row
-        for item in matched
-        for row in grouped.get(("cuda", item["comparison_key"]), [])
+        for key in sorted(matched_keys)
+        for row in grouped.get(("cuda", key), [])
     ]
-    amd_child_retries = sum(child_retry_counts[("amd", key)] for key in amd_keys)
-    amd_retry_involved = sum(retry_involved_counts[("amd", key)] for key in amd_keys)
-    amd_recoveries = sum(recovery_counts[("amd", key)] for key in amd_keys)
-    matched_keys = {row["comparison_key"] for row in matched}
+    amd_key_set = set(amd_keys)
+    amd_child_retries = counter_total(child_retry_counts, "amd", amd_key_set)
+    amd_retry_involved = counter_total(retry_involved_counts, "amd", amd_key_set)
+    amd_recoveries = counter_total(recovery_counts, "amd", amd_key_set)
     comparable_amd_groups = [
         row
-        for item in matched
-        for row in grouped.get(("amd", item["comparison_key"]), [])
+        for key in sorted(matched_keys)
+        for row in grouped.get(("amd", key), [])
     ]
-    comparable_amd_child_retries = sum(
-        child_retry_counts[("amd", key)] for key in matched_keys
+    comparable_amd_child_retries = counter_total(
+        child_retry_counts, "amd", matched_keys
     )
-    comparable_amd_retry_involved = sum(
-        retry_involved_counts[("amd", key)] for key in matched_keys
+    comparable_amd_retry_involved = counter_total(
+        retry_involved_counts, "amd", matched_keys
     )
-    comparable_amd_recoveries = sum(
-        recovery_counts[("amd", key)] for key in matched_keys
+    comparable_amd_recoveries = counter_total(
+        recovery_counts, "amd", matched_keys
     )
-    cuda_child_retries = sum(child_retry_counts[("cuda", key)] for key in matched_keys)
-    cuda_retry_involved = sum(retry_involved_counts[("cuda", key)] for key in matched_keys)
-    cuda_recoveries = sum(recovery_counts[("cuda", key)] for key in matched_keys)
+    cuda_child_retries = counter_total(child_retry_counts, "cuda", matched_keys)
+    cuda_retry_involved = counter_total(retry_involved_counts, "cuda", matched_keys)
+    cuda_recoveries = counter_total(recovery_counts, "cuda", matched_keys)
     amd_totals = _comparison_side(
         amd_groups, cohort_builds, amd_child_retries, amd_recoveries, amd_retry_involved
     )
@@ -2149,13 +2201,15 @@ def _platform_comparison(
         "source_pipeline": "ci",
         "cohort_build_count": cohort_builds,
         "summary": {
-            "amd_base_group_count": len(rows),
+            "amd_base_group_count": len(amd_keys),
+            "amd_comparison_row_count": len(rows),
             "amd_variant_count": len(amd_groups),
-            "label_matched_base_group_count": len(label_matched),
-            "matched_base_group_count": len(matched),
-            "comparable_base_group_count": len(matched),
-            "review_required_base_group_count": len(rows) - len(matched),
-            "unmatched_amd_base_group_count": len(rows) - len(label_matched),
+            "label_matched_base_group_count": len(label_matched_keys),
+            "matched_base_group_count": len(matched_keys),
+            "comparable_base_group_count": len(matched_keys),
+            "comparable_variant_pair_count": len(matched),
+            "review_required_base_group_count": len(amd_keys) - len(matched_keys),
+            "unmatched_amd_base_group_count": len(amd_keys) - len(label_matched_keys),
             "matched_cuda_variant_count": len(matched_cuda_groups),
             "amd": amd_totals,
             "comparable_amd": comparable_amd_totals,
@@ -2164,7 +2218,7 @@ def _platform_comparison(
         "matching": {
             "amd_rule": "AMD: prefix, MI hardware, or amd_mi* queue",
             "cuda_rule": "NVIDIA hardware or known CUDA queue; Intel GPU, CPU, NPU, and unknown groups excluded",
-            "equivalence_rule": "case-insensitive exact label after removing only AMD:/mi*_n wrapper decoration; comparative deltas require one AMD variant, one explicit NVIDIA variant, and hardware-neutral wording",
+            "equivalence_rule": "case-insensitive exact label after removing only AMD:/mi*_n wrapper decoration; each comparative row pairs one AMD hardware variant with one explicit NVIDIA reference and hardware-neutral wording",
             "scope": "completed upstream ci branch=main builds in the strict retained cohort",
             "frequency_unit": "terminal attempts per 100 cohort builds; child retry share uses retry_source rows over terminal attempts",
         },

--- a/tests/vllm/test_dashboard_audit.py
+++ b/tests/vllm/test_dashboard_audit.py
@@ -282,6 +282,59 @@ def test_operations_audit_rejects_mixed_latest_and_retained_amd_counts(tmp_path)
     assert "operations-amd-latest-catalog-count" in codes
 
 
+def test_operations_audit_reconciles_platform_comparison_counts(tmp_path):
+    ci = tmp_path / "data/vllm/ci"
+    ci.mkdir(parents=True)
+    (ci / "operations_v2.json").write_text(json.dumps({
+        "schema_version": 2,
+        "reliability": {
+            "available": True,
+            "source_pipeline": "ci",
+            "group_catalog": [
+                {"id": "amd-1"},
+                {"id": "amd-2"},
+                {"id": "cuda-1"},
+            ],
+            "platform_comparison": {
+                "available": True,
+                "source_pipeline": "ci",
+                "summary": {
+                    "amd_base_group_count": 99,
+                    "amd_comparison_row_count": 1,
+                    "amd_variant_count": 2,
+                    "label_matched_base_group_count": 1,
+                    "matched_base_group_count": 1,
+                    "comparable_base_group_count": 1,
+                    "comparable_variant_pair_count": 1,
+                    "review_required_base_group_count": 0,
+                    "unmatched_amd_base_group_count": 0,
+                    "matched_cuda_variant_count": 1,
+                },
+                "rows": [{
+                    "comparison_key": "shared test",
+                    "comparison_eligible": True,
+                    "match_status": "exact_cuda_pair",
+                    "amd": {
+                        "variant_count": 1,
+                        "group_ids": ["amd-1"],
+                    },
+                    "cuda": {
+                        "variant_count": 1,
+                        "group_ids": ["cuda-1"],
+                    },
+                }],
+            },
+        },
+    }))
+
+    audit = DashboardAudit(tmp_path)
+    audit.audit_operations_v2()
+
+    assert "operations-platform-comparison-counts" in {
+        finding.code for finding in audit.report.errors
+    }
+
+
 def test_operations_audit_reconciles_identity_families_independently(
     tmp_path,
 ):

--- a/tests/vllm/test_operations_snapshot.py
+++ b/tests/vllm/test_operations_snapshot.py
@@ -2443,6 +2443,82 @@ def test_platform_comparison_is_amd_first_and_matches_only_exact_cuda_labels():
     assert unmatched["cuda"]["variant_count"] == 0
 
 
+def test_platform_comparison_pairs_each_amd_variant_with_one_cuda_reference():
+    def group(group_id, name, hardware, queue, runs=10):
+        return {
+            "id": group_id,
+            "name": name,
+            "raw_names": [name],
+            "hardware": hardware,
+            "queues": [queue],
+            "runs": runs,
+            "build_count": runs,
+            "passed": runs,
+            "failed": 0,
+            "soft_failed": 0,
+            "incident_count": 0,
+            "incident_rate_pct": 0,
+            "mixed_outcomes": False,
+            "latest_state": "passed",
+            "latest_observed_at": "2026-08-07T00:00:00Z",
+            "latest_url": (
+                "https://buildkite.com/vllm/ci/builds/1/steps/canvas"
+                f"?jid={group_id}"
+            ),
+            "median_dur": 5,
+            "p90_dur": 10,
+            "max_dur": 11,
+            "duration_basis": "job_wall",
+        }
+
+    comparison = ops._platform_comparison(
+        [
+            group(
+                "amd-mi300",
+                "AMD: Shared Test (mi300_1)",
+                "mi300",
+                "amd_mi300_1",
+            ),
+            group(
+                "amd-mi355",
+                "AMD: Shared Test (mi355_1)",
+                "mi355",
+                "amd_mi355_1",
+            ),
+            group("cuda-h200", "Shared Test", "h200", "h200_35gb"),
+        ],
+        {
+            "available": True,
+            "retry_attempts": [
+                {
+                    "group_id": "amd-mi300",
+                    "name": "AMD: Shared Test (mi300_1)",
+                    "retry_source": {"job_id": "original"},
+                }
+            ],
+            "failed_then_passed_recoveries": [],
+        },
+        cohort_builds=10,
+    )
+
+    assert comparison["summary"]["amd_base_group_count"] == 1
+    assert comparison["summary"]["amd_comparison_row_count"] == 2
+    assert comparison["summary"]["matched_base_group_count"] == 1
+    assert comparison["summary"]["comparable_variant_pair_count"] == 2
+    assert comparison["summary"]["matched_cuda_variant_count"] == 1
+    assert len(comparison["rows"]) == 2
+    assert all(row["comparison_eligible"] for row in comparison["rows"])
+    assert all(row["match_status"] == "exact_cuda_pair" for row in comparison["rows"])
+    assert all(row["amd"]["variant_count"] == 1 for row in comparison["rows"])
+    assert all(row["cuda"]["variant_count"] == 1 for row in comparison["rows"])
+    assert {row["amd"]["group_ids"][0] for row in comparison["rows"]} == {
+        "amd-mi300",
+        "amd-mi355",
+    }
+    assert comparison["summary"]["matched_cuda"]["runs"] == 10
+    assert sum(row["amd"]["child_retry_attempts"] for row in comparison["rows"]) == 1
+
+
 def test_upstream_reliability_fails_closed_without_a_strict_main_cohort():
     payload = ops._reliability(
         {

--- a/tests/vllm/test_ops_v2_frontend.py
+++ b/tests/vllm/test_ops_v2_frontend.py
@@ -235,7 +235,7 @@ def test_amd_health_and_platform_comparison_are_distinct_first_visit_surfaces():
         "function platformComparison",
         "function openPlatformComparisonDetail",
         "function renderPlatformFlakes",
-        "ACTIVE AMD GROUPS",
+        "ACTIVE AMD VARIANTS",
         "AMD incident comparison",
     ):
         assert contract in OPS_JS
@@ -249,6 +249,8 @@ def test_amd_health_and_platform_comparison_are_distinct_first_visit_surfaces():
         assert contract in OPS_CSS
     assert "name: 'flake-comparison'" in OPS_JS
     assert "comparisonFlakeColumns" in OPS_JS
+    assert "const seenGroupSets = new Set()" in OPS_JS
+    assert "if (seenGroupSets.has(identity)) return" in OPS_JS
     assert "renderGroupOverviewCharts(host, catalog" not in OPS_JS
 
     health = OPS_DATA["amd_test_health"]
@@ -270,9 +272,18 @@ def test_amd_health_and_platform_comparison_are_distinct_first_visit_surfaces():
     comparison = OPS_DATA["reliability"]["platform_comparison"]
     assert comparison["available"] is True
     assert comparison["source_pipeline"] == "ci"
-    assert comparison["summary"]["amd_base_group_count"] == len(comparison["rows"])
-    assert comparison["summary"]["matched_base_group_count"] > 0
-    assert comparison["summary"]["comparable_base_group_count"] + comparison["summary"]["review_required_base_group_count"] == len(comparison["rows"])
+    comparison_keys = {row["comparison_key"] for row in comparison["rows"]}
+    eligible = [row for row in comparison["rows"] if row["comparison_eligible"]]
+    matched_keys = {row["comparison_key"] for row in eligible}
+    assert comparison["summary"]["amd_base_group_count"] == len(comparison_keys)
+    assert comparison["summary"].get(
+        "amd_comparison_row_count", len(comparison["rows"])
+    ) == len(comparison["rows"])
+    assert comparison["summary"]["matched_base_group_count"] == len(matched_keys)
+    assert comparison["summary"].get(
+        "comparable_variant_pair_count", len(eligible)
+    ) == len(eligible)
+    assert comparison["summary"]["comparable_base_group_count"] + comparison["summary"]["review_required_base_group_count"] == comparison["summary"]["amd_base_group_count"]
     assert all(row["amd"]["variant_count"] > 0 for row in comparison["rows"])
     assert all(isinstance(row["match_issues"], list) for row in comparison["rows"])
     assert all(row["comparison_eligible"] == (row["match_status"] == "exact_cuda_pair") for row in comparison["rows"])

--- a/tests/vllm/test_workflow_integrity.py
+++ b/tests/vllm/test_workflow_integrity.py
@@ -421,6 +421,16 @@ class TestHourlyMasterWorkflow:
         has_frequent = any("* * * *" in c for c in crons)
         assert has_frequent, f"hourly-master.yml must have a recurring cron, found: {crons}"
 
+    def test_full_refresh_runs_once_per_hour(self):
+        data = _load_workflow("hourly-master.yml")
+        triggers = data.get(True, data.get("on", {}))
+        schedules = triggers.get("schedule", []) if isinstance(triggers, dict) else []
+        crons = [s.get("cron", "") for s in schedules]
+        assert crons == ["13 * * * *"], (
+            "The full refresh takes about 25 minutes and must not be queued "
+            f"more than once per hour; found {crons}"
+        )
+
     def test_syncs_ci_data_from_gh_pages(self):
         text = _load_workflow_text("hourly-master.yml")
         assert "git fetch origin gh-pages" in text or "git show origin/gh-pages" in text


### PR DESCRIPTION
## What changed

- run the expensive full dashboard refresh once per hour instead of every 30 minutes
- split shared AMD base labels into one-to-one AMD-variant/CUDA comparison rows when there is one explicit CUDA reference
- deduplicate reused CUDA references in windowed frontend totals
- validate comparison counts, catalog references, and exact-pair eligibility in the strict data audit
- replace the brittle requirement that live data must always contain a positive pair count with reconciliation invariants

## Root cause

The full collection regularly takes about 25 minutes but was scheduled twice per hour behind a non-canceling deploy lock. Separately, newly observed AMD hardware variants caused every formerly exact base-label comparison to be classified as `shared_amd_base_label`, driving `matched_base_group_count` to zero and failing issue #391 even though the data was otherwise valid.

## Impact

Refreshes have recovery margin, and additional AMD hardware variants no longer collapse the entire comparison surface. Comparisons remain one-to-one and hardware-specific, while the audit blocks inconsistent counts or invalid catalog references.

## Validation

- regenerated `operations_v2` snapshot: 31 comparable base labels / 54 exact variant pairs
- strict dashboard audit: 0 errors, 0 warnings
- Python 3.12 full suite on regenerated data: 1,744 passed, 11 skipped
- Ruff: passed
- `node --check docs/assets/js/ops-v2.js`: passed